### PR TITLE
[Parser] implement syntacic sugar for defining function with let

### DIFF
--- a/test/frontend/parsing/parser-resources/parser_input_syntax_sugar.expect
+++ b/test/frontend/parsing/parser-resources/parser_input_syntax_sugar.expect
@@ -1,0 +1,15 @@
+let x = 42
+;;
+
+let (x : int) = 42
+;;
+
+let (x : int) = 42
+;;
+
+let (x : int -> _ -> _) = (fun (y : int) z -> y + z)
+;;
+
+let (x : int -> int) = (fun (y : int) -> y + z)
+;;
+

--- a/test/frontend/parsing/parser-resources/parser_input_syntax_sugar.soml
+++ b/test/frontend/parsing/parser-resources/parser_input_syntax_sugar.soml
@@ -1,0 +1,14 @@
+let x = 42
+;;
+
+let x : int = 42
+;;
+
+let (x : int) = 42
+;;
+
+let x (y : int) z = y + z
+;;
+
+let x (y : int) : int = y + z
+;;

--- a/test/frontend/parsing/parser_test.ml
+++ b/test/frontend/parsing/parser_test.ml
@@ -23,6 +23,8 @@ let tests = OUnit2.(>:::) "parser_test" [
     OUnit2.(>::) "test_integration" (fun _ ->
         let path = _get_full_path "parser_input_mixed" in
         _check_parser_pp_ast path;
+        let path = _get_full_path "parser_input_syntax_sugar" in
+        _check_parser_pp_ast path;
       );
   ]
 


### PR DESCRIPTION
```ocaml
let f (x : int) y : bool = e 
(* is desugared into and represented in AST as *)
let (f : int -> _ -> bool) = (fun (x : int) y -> e)
```
