### PR TITLE
Type annotation

### DIFF
--- a/lib/frontend/ast.ml
+++ b/lib/frontend/ast.ml
@@ -25,6 +25,7 @@ type opt_typed_var =
 type expression =
   { expr_desc : expr_desc
   ; expr_span : Span.t
+  ; expr_typ  : typ option (* (e : T), or filled in by typer *)
   }
 
 and binding =

--- a/lib/frontend/frontend_pp.ml
+++ b/lib/frontend/frontend_pp.ml
@@ -335,6 +335,11 @@ let pp_ast_structure (structure : Ast.structure) =
   p.buffer
 ;;
 
+let pp_ast_expr (expr : Ast.expression) =
+  let p = _create_printer () in
+  _pp_ast_expr p expr;
+  p.buffer
+;;
 
 let pp_typer_error (err : Errors.typer_error) =
   match err with

--- a/lib/frontend/frontend_pp.mli
+++ b/lib/frontend/frontend_pp.mli
@@ -4,6 +4,7 @@
 val pp_token            : Token.t -> string
 val pp_token_desc       : Token.desc -> string
 val pp_ast_structure    : Ast.structure -> string
+val pp_ast_expr         : Ast.expression -> string
 val pp_ast_typ          : Ast.typ -> string
 
 val pp_lexer_error      : Errors.lexer_error -> string

--- a/lib/frontend/frontend_pp.mli
+++ b/lib/frontend/frontend_pp.mli
@@ -7,6 +7,9 @@ val pp_ast_structure    : Ast.structure -> string
 val pp_ast_expr         : Ast.expression -> string
 val pp_ast_typ          : Ast.typ -> string
 
+val pp_ast_structure_with_typ_annot : Ast.structure -> string
+val pp_ast_expr_with_typ_annot      : Ast.expression -> string
+
 val pp_lexer_error      : Errors.lexer_error -> string
 val pp_parser_error     : Errors.parser_error -> string
 val pp_ast_interp_error : Errors.ast_interp_error -> string

--- a/lib/frontend/interp/ast_interp.ml
+++ b/lib/frontend/interp/ast_interp.ml
@@ -84,14 +84,15 @@ let _interp_const (const : Ast.constant) : value =
 ;;
 
 (* ASSUME [opstr] is a primitive operator *)
-let _interp_prim_op (ctx : context) (opstr : string) (where : Span.t) : value =
+let _interp_prim_op (ctx : context) (opstr : string) (expr_span : Span.t) : value =
   let args = ["a"; "b"] in  (* could cache this geneartion but whatever *)
-  let ident_expr = { Ast.expr_desc = Exp_ident opstr; expr_span = where } in
+  let expr_typ = None in
+  let ident_expr = { Ast.expr_desc = Exp_ident opstr; expr_span; expr_typ } in
   let arg_exprs = List.map
-      (fun str -> { Ast.expr_desc = Exp_ident str; expr_span = where }) args
+      (fun str -> { Ast.expr_desc = Exp_ident str; expr_span; expr_typ }) args
   in
-  let body_expr = { Ast.expr_desc = Exp_apply (ident_expr, arg_exprs)
-                  ; expr_span = where } in
+  let body_expr = { Ast.expr_desc = Exp_apply (ident_expr, arg_exprs);
+                    expr_span; expr_typ  } in
   Closure (["a"; "b"], body_expr, ref ctx)
 ;;
 
@@ -176,7 +177,7 @@ and _interp_apply (ctx : context)
   : value =
     (* inline primop application, or get stuck *)
   match func with
-  | { expr_desc = Exp_ident name; expr_span } ->
+  | { expr_desc = Exp_ident name; expr_span; expr_typ = None } ->
     _interp_potential_primop_apply ctx name expr_span args span
   | _ ->
     let func_value = _interp_expr ctx func in

--- a/lib/frontend/typing/typer_ctx.ml
+++ b/lib/frontend/typing/typer_ctx.ml
@@ -108,7 +108,7 @@ let unify t expect actual actual_span =
   let actual = Substs.apply_to_typ substs actual in
   let t = { t with substs } in
   match err_opt with
-  | None -> let t = _update_envs_with_substs t in (t, actual)
+  | None -> let t = _update_envs_with_substs t in (t, expect)
   | Some err ->
     let expect = Substs.apply_to_typ substs expect in
     let err = match err with
@@ -119,7 +119,7 @@ let unify t expect actual actual_span =
     in
     (* update types based on the information gathered before mismatch *)
     let t = { t with rev_errs = err::t.rev_errs } in
-    (t, actual)
+    (t, expect)
 ;;
 
 let unify_apply t func_typ func_span arg_typ_span_pairs =

--- a/test/frontend/typing/infer_test.ml
+++ b/test/frontend/typing/infer_test.ml
@@ -21,8 +21,8 @@ let _check_infer_struct (filepath_no_suffix : string) : unit =
 let tests = OUnit2.(>:::) "infer_test" [
 
     OUnit2.(>::) "test_integration" (fun _ ->
-        let path = _get_full_path "infer_input_mixed" in
-        _check_infer_struct path;
+        _check_infer_struct (_get_full_path "infer_input_mixed");
+        _check_infer_struct (_get_full_path "annot");
       );
   ]
 

--- a/test/frontend/typing/infer_test.ml
+++ b/test/frontend/typing/infer_test.ml
@@ -10,7 +10,7 @@ let _check_infer_struct (filepath_no_suffix : string) : unit =
   let result =
     match Driver.type_file filepath with
     | Error msg -> msg
-    | Ok ast -> Frontend_pp.pp_ast_structure ast
+    | Ok ast -> Frontend_pp.pp_ast_structure_with_typ_annot ast
   in
   let expect_path = String.append filepath_no_suffix ".expect" in
   let actual_path = String.append filepath_no_suffix ".actual" in
@@ -23,6 +23,7 @@ let tests = OUnit2.(>:::) "infer_test" [
     OUnit2.(>::) "test_integration" (fun _ ->
         _check_infer_struct (_get_full_path "infer_input_mixed");
         _check_infer_struct (_get_full_path "annot");
+        _check_infer_struct (_get_full_path "annot_error");
       );
   ]
 

--- a/test/frontend/typing/resources/annot.expect
+++ b/test/frontend/typing/resources/annot.expect
@@ -1,3 +1,14 @@
-[Typer]: Expected type <bool> but got <int> at <(2, 9)-(2, 19)>
-[Typer]: Expected type <int> but got <bool> at <(8, 9)-(8, 9)>
-[Typer]: Expected type <bool> but got <int> at <(11, 7)-(11, 7)>
+let (-- : int -> int -> int) = ((fun (x : int) (y : int) -> ((- : int -> int -> int) (x : int) (y : int) : int)) : int -> int -> int)
+;;
+
+let (x : int) = ((-- : int -> int -> int) (88 : int) (99 : int) : int)
+and (y : int -> int -> int) = (-- : int -> int -> int)
+;;
+
+let rec (f : int -> 'X8) = ((fun (x : int) -> 
+  (if (true : bool)
+  then ((f : int -> 'X8) (x : int) : 'X8)
+  else ((f : int -> 'X8) (42 : int) : 'X8) : 'X8)
+) : int -> 'X8)
+;;
+

--- a/test/frontend/typing/resources/annot.expect
+++ b/test/frontend/typing/resources/annot.expect
@@ -1,0 +1,3 @@
+[Typer]: Expected type <bool> but got <int> at <(2, 9)-(2, 19)>
+[Typer]: Expected type <int> but got <bool> at <(8, 9)-(8, 9)>
+[Typer]: Expected type <bool> but got <int> at <(11, 7)-(11, 7)>

--- a/test/frontend/typing/resources/annot.soml
+++ b/test/frontend/typing/resources/annot.soml
@@ -1,0 +1,11 @@
+
+let x = (42 : bool)
+;;
+
+let y =
+  (if (true : bool)
+   then let x = 42 in (x * x : int)
+   else x)
+;;
+
+(x && y : int)

--- a/test/frontend/typing/resources/annot.soml
+++ b/test/frontend/typing/resources/annot.soml
@@ -1,11 +1,11 @@
 
-let x = (42 : bool)
+let (--) x y = x - y
 ;;
 
-let y =
-  (if (true : bool)
-   then let x = 42 in (x * x : int)
-   else x)
+let x = (88 -- 99)
+and y = (--)
 ;;
 
-(x && y : int)
+let rec f x =
+  if true then f x else f 42
+;;

--- a/test/frontend/typing/resources/annot_error.expect
+++ b/test/frontend/typing/resources/annot_error.expect
@@ -1,0 +1,3 @@
+[Typer]: Expected type <bool> but got <int> at <(2, 9)-(2, 19)>
+[Typer]: Expected type <int> but got <bool> at <(8, 9)-(8, 9)>
+[Typer]: Expected type <bool> but got <int> at <(11, 7)-(11, 7)>

--- a/test/frontend/typing/resources/annot_error.soml
+++ b/test/frontend/typing/resources/annot_error.soml
@@ -1,0 +1,11 @@
+
+let x = (42 : bool)
+;;
+
+let y =
+  (if (true : bool)
+   then let x = 42 in (x * x : int)
+   else x)
+;;
+
+(x && y : int)


### PR DESCRIPTION
I thought about it a lot, and decided to not go with another `Typed_ast` IR.
Although OCaml does that, I just don't see the benefit over the code dup it would bring about, so far.
So I'm just adding an optional type annotation field to `Ast.expression`.

Again, KISS.