### PR TITLE
Closure

### DIFF
--- a/lib/backend/cir.ml
+++ b/lib/backend/cir.ml
@@ -1,0 +1,332 @@
+open Pervasives
+
+type constant =
+  | CInt of int
+  | CBool of bool
+
+type expr =
+  | Cconst of constant
+  | Cident of string
+  | Cmk_closure of mk_closure
+  | Clet of (string * expr) list * expr
+  | Cletrec of (string * letrec_rhs) list * expr
+  | Cif of expr * expr * expr
+  | Cprimop of Primops.op_kind * expr list
+  | Capply of expr * expr list
+
+and mk_closure =
+  { func_name : string
+  ; free_vars : string list
+  }
+
+and letrec_rhs =
+  | Rhs_const of constant
+  | Rhs_mkcls of mk_closure
+
+type closure =
+  { args : string list
+  ; free_vars : string list
+  ; body : expr
+  }
+
+type t =
+  { funcs : (string, closure) Map.t
+  ; expr : expr
+  }
+
+
+(* Context for the translation process from AST to CIR.
+ * I decided not to make a new module for this since it's pretty simplistic *)
+type context =
+  { funcs : (string, closure) Map.t
+  ; namer : Var_namer.t
+  }
+
+let _init_ctx =
+  { funcs = Map.empty String.compare
+  ; namer = Var_namer.init
+  }
+;;
+
+let _gen_new_var_name (ctx : context) (prefix : string) : (context * string) =
+  let namer, new_name = Var_namer.gen_new_var_with_prefix ctx.namer prefix in
+  ({ ctx with namer }, new_name)
+;;
+
+(* Apply [_gen_new_var_name ctx prefix] [count] # of times *)
+let _gen_new_var_names (ctx : context) (prefix : string) (count : int)
+  : (context * string list) =
+  List.fold_right
+    (fun _ (ctx, extra_arg_names) ->
+       let ctx, arg_name = _gen_new_var_name ctx prefix in
+       (ctx, arg_name::extra_arg_names))
+    (List.init count (fun x -> x))
+    (ctx, [])
+;;
+
+let _add_closure (ctx : context) (name : string) (cls : closure) : context =
+  { ctx with funcs = Map.add name cls ctx.funcs }
+;;
+
+let _get_all_closures (ctx : context) : (string, closure) Map.t =
+  ctx.funcs
+;;
+
+(* NOTE We can optimize free_var compuation by caching free_vars of last
+ * examined expression in context, if it becomes a performance bottleneck *)
+let _free_vars_in_expr (expr : Ast.expression) : string Set.t =
+  let rec go (free_vars : string Set.t) (expr : Ast.expression)
+    : string Set.t =
+    match expr.expr_desc with
+    | Exp_const _ -> free_vars
+    | Exp_ident name  -> Set.add name free_vars
+    | Exp_fun (otvs, body) ->
+      let names = List.map (fun (otv : Ast.opt_typed_var) -> otv.var) otvs in
+      let body_fvs = go (Set.empty String.compare) body in
+      let body_fvs = List.fold_right Set.remove names body_fvs in
+      Set.union free_vars body_fvs
+
+    | Exp_if (cnd, thn, els) ->
+      let free_vars = go free_vars cnd in
+      let free_vars = go free_vars thn in
+      go free_vars els
+
+    | Exp_let (_, bds, body) ->
+      let names = List.map (fun (bd : Ast.binding) -> bd.binding_lhs.var) bds in
+      let body_fvs = go (Set.empty String.compare) body in
+      let body_fvs = List.fold_right Set.remove names body_fvs in
+      Set.union free_vars body_fvs
+
+    | Exp_apply (func, args) ->
+      let free_vars = go free_vars func in
+      List.fold_left go free_vars args
+  in
+  go (Set.empty String.compare) expr
+;;
+
+let rec _count_args_in_typ (typ : Ast.typ) : int =
+  match typ with
+  | Typ_arrow (_, out_typ) -> 1 + (_count_args_in_typ out_typ)
+  | _ -> 0
+;;
+
+
+(* Translate AST expression to CIR expression *)
+let rec _from_ast_expr (ctx : context) (expr : Ast.expression)
+  : (context * expr) =
+  match expr.expr_desc with
+  | Exp_const const -> (ctx, Cconst (_from_ast_const const))
+  | Exp_ident name  -> (ctx, Cident name)
+
+  | Exp_fun (otvs, body) ->
+    let ctx, c_mkcls = _from_ast_func ctx otvs body in
+    (ctx, Cmk_closure c_mkcls)
+
+  | Exp_if (cnd, thn, els) ->
+    let ctx, c_cnd = _from_ast_expr ctx cnd in
+    let ctx, c_thn = _from_ast_expr ctx thn in
+    let ctx, c_els = _from_ast_expr ctx els in
+    let c_if = Cif (c_cnd, c_thn, c_els) in
+    (ctx, c_if)
+
+  | Exp_let (rec_flag, bds, body) ->
+    let ctx, c_body = _from_ast_expr ctx body in (* order shouldn't matter *)
+    _from_ast_let_bindings ctx rec_flag bds c_body
+
+  | Exp_apply (func, args) -> _from_ast_apply ctx func args
+
+and _from_ast_const (const : Ast.constant) : constant =
+  match const with
+  | Const_Int n -> CInt n
+  | Const_Bool b -> CBool b
+
+and _from_ast_func (ctx : context)
+    (otvs : Ast.opt_typed_var list) (body : Ast.expression)
+  : (context * mk_closure) =
+  let arg_names = List.map (fun (otv : Ast.opt_typed_var) -> otv.var) otvs in
+  let ctx, func_name = _gen_new_var_name ctx "closure" in
+  let ctx, cls_body = _from_ast_expr ctx body in
+  let free_vars = _free_vars_in_expr body
+                  |> List.fold_right Set.remove arg_names
+                  |> Set.to_list in
+  let cls = { args = arg_names; free_vars; body = cls_body } in
+  let ctx = _add_closure ctx func_name cls in
+  let mk_cls = { func_name; free_vars } in
+  (ctx, mk_cls)
+
+(* Use [c_body] as the body of translated let *)
+and _from_ast_let_bindings (ctx : context) (rec_flag : Ast.rec_flag)
+    (bds : Ast.binding list) (c_body : expr)
+  : (context * expr) =
+
+  let _from_one_let_binding (ctx : context) (bd : Ast.binding)
+    : (context * (string * expr)) =
+    let ctx, c_rhs = _from_ast_expr ctx bd.binding_rhs in
+    let bd_name = bd.binding_lhs.var in
+    (ctx, (bd_name, c_rhs))
+  in
+  let _from_one_letrec_binding (ctx : context) (bd : Ast.binding)
+    : (context * (string * letrec_rhs)) =
+    let bd_name = bd.binding_lhs.var in
+    match bd.binding_rhs.expr_desc with
+    | Exp_const const ->
+      let c_const = _from_ast_const const in
+      (ctx, (bd_name, Rhs_const c_const))
+
+    | Exp_fun (otvs, body) ->
+      let ctx, c_mkcls = _from_ast_func ctx otvs body in
+      (ctx, (bd_name, Rhs_mkcls c_mkcls))
+
+    | _ -> failwith "[Cir._from_ast_let_bindings] Illegal RHS of Letrec"
+  in
+
+  match rec_flag with
+  | Nonrecursive -> (* simply translate each binding *)
+    let ctx, c_bds = List.fold_right
+        (fun bd (ctx, c_bds) ->
+           let ctx, c_bd = _from_one_let_binding ctx bd in
+           (ctx, c_bd::c_bds))
+        bds (ctx, [])
+    in
+    let c_let = Clet (c_bds, c_body) in
+    (ctx, c_let)
+
+  | Recursive -> (* Could do some abstraction. Borderline case *)
+    let ctx, c_bds = List.fold_right
+        (fun bd (ctx, c_bds) ->
+           let ctx, c_bd = _from_one_letrec_binding ctx bd in
+           (ctx, c_bd::c_bds))
+        bds (ctx, [])
+    in
+    let c_let = Cletrec (c_bds, c_body) in
+    (ctx, c_let)
+
+(* handle currying *)
+and _from_ast_apply (ctx : context)
+    (func : Ast.expression) (args : Ast.expression list)
+  : (context * expr) =
+  let expected_args_num = match func.expr_typ with
+    | Some typ -> _count_args_in_typ typ
+    | None ->
+      failwith "[Cir._from_ast_apply] func expr should be annotated with type"
+  in
+  let extra_args_needed = expected_args_num - (List.length args) in
+  if extra_args_needed < 0
+  then failwith "[Cir._from_ast_apply] can't provide more args than expected";
+  (* translate func expr and provided args *)
+  let ctx, c_func = _from_ast_expr ctx func in
+  let ctx, c_args =
+    List.fold_right
+      (fun arg (ctx, c_args) ->
+         let ctx, c_arg = _from_ast_expr ctx arg in
+         (ctx, c_arg::c_args))
+      args (ctx, [])
+  in
+  if extra_args_needed = 0
+  then (ctx, Capply (c_func, c_args))
+  else (* extra_args_needed > 0, can't apply the function without currying *)
+    _curry_apply ctx c_func c_args extra_args_needed
+
+(* (* ASSUME e1 takes 3 args *)
+ * e1 e2
+ * ----->
+ * let f = e1
+ * and x = e2 *)
+and _curry_apply (ctx : context)
+    (c_func : expr) (c_args : expr list) (extra_args_needed : int)
+  : (context * expr) =
+  let ctx, func_name = _gen_new_var_name ctx "curried_func" in
+  let func_bind = (func_name, c_func) in
+  let ctx, provided_arg_bds =
+    List.fold_right (* binding order matters for making Capply below *)
+      (fun c_arg (ctx, provided_arg_bds) ->
+         let ctx, arg_name = _gen_new_var_name ctx "curried_func_free_arg" in
+         let provided_arg_bds = (arg_name, c_arg)::provided_arg_bds in
+         (ctx, provided_arg_bds))
+      c_args (ctx, [])
+  in
+  let ctx, extra_arg_names =
+    _gen_new_var_names ctx "curried_func_arg" extra_args_needed
+  in
+  let provided_arg_names = List.map (fun (var, _) -> var) provided_arg_bds in
+  let all_arg_names = List.append provided_arg_names extra_arg_names in
+  let cls_body = Capply (Cident func_name,
+                         List.map (fun name -> Cident name) all_arg_names) in
+  let cls = { args = extra_arg_names
+            ; free_vars = provided_arg_names
+            ; body = cls_body } in
+  let ctx = _add_closure ctx func_name cls in
+  let mk_cls = { func_name; free_vars = provided_arg_names } in
+  let let_binds = func_bind::provided_arg_bds in
+  let c_let = Clet (let_binds, Cmk_closure mk_cls) in
+  (ctx, c_let)
+;;
+
+
+(* let rec x1 = e1;;
+ * let x2 = e2;;
+ * e3;;
+ * e4;;
+ * --->
+ * let rec x1 = e1 in
+ * let x2 = e2 in
+ * let _ = e3 in
+ * let _ = e4 in
+ * body_e *)
+let _from_ast_struct_item (ctx : context) (body_ce : expr)
+    (item : Ast.struct_item) : (context * expr) =
+  match item.struct_item_desc with
+  | Struct_eval expr -> 
+    let ctx, cexpr = _from_ast_expr ctx expr in
+    let ctx, new_name = _gen_new_var_name ctx "struct_item" in
+    let bds = [(new_name, cexpr)] in
+    let let_cexpr = Clet (bds, body_ce) in
+    (ctx, let_cexpr)
+
+  | Struct_bind (rec_flag, bds) ->
+    _from_ast_let_bindings ctx rec_flag bds body_ce
+;;
+
+(* Manually add all primitive operators into the cir closure context and create
+ * bindings for them. NOTE `external` syntax would move this to source *)
+let _add_primop_closures (ctx : context) : (context * (string * expr) list) =
+
+  let make_primop_closure (ctx : context) (info :Primops.op_info)
+    : (context * closure) =
+    let arg_count = _count_args_in_typ info.typ in
+    let ctx, args = _gen_new_var_names ctx "prim_arg" arg_count in
+    let free_vars = [] in
+    let arg_idents = List.map (fun id -> Cident id) args in
+    let body = Cprimop (info.kind, arg_idents) in
+    let cls = { args; free_vars; body } in
+    (ctx, cls)
+  in
+  (* e.g., <closure> (+) x y = (AddInt, [x; y]) *)
+  List.fold_right
+    (fun (info : Primops.op_info) (ctx, bds) ->
+       let ctx, func_name = _gen_new_var_name ctx info.opstr in
+       let ctx, cls = make_primop_closure ctx info in
+       let ctx = _add_closure ctx func_name cls in
+       let mkcls = { func_name; free_vars = [] } in (* primop has no freevars *)
+       let bd = (info.opstr, Cmk_closure mkcls) in
+       (ctx, bd::bds)
+    )
+    Primops.all_op_infos (ctx, [])
+;;
+
+(* NOTE ASSUME the translation order is irrelevant.
+ * This makes translation easier for the let bindings *)
+let from_ast_struct structure =
+  let ctx = _init_ctx in
+  let dummy_body = Cconst (CInt 42) in (* no effect, simplifies code *)
+  let ctx, final_ce =
+    List.fold_right
+      (fun item (ctx, final_ce) ->
+         _from_ast_struct_item ctx final_ce item)
+      structure (ctx, dummy_body)
+  in
+  let ctx, bds = _add_primop_closures ctx in
+  { funcs = _get_all_closures ctx
+  ; expr = Clet (bds, final_ce)
+  }
+;;

--- a/lib/backend/cir.mli
+++ b/lib/backend/cir.mli
@@ -36,4 +36,6 @@ type t =
   ; expr : expr
   }
 
+(** [from_ast_struct struct] returns a CIR representation of [struct].
+    ASSUME [struct] is well-typed based on Typer. *)
 val from_ast_struct : Ast.structure -> t

--- a/lib/backend/cir.mli
+++ b/lib/backend/cir.mli
@@ -1,0 +1,39 @@
+open Pervasives
+
+type constant =
+  | CInt of int
+  | CBool of bool
+
+type expr =
+  | Cconst of constant
+  | Cident of string
+  | Cmk_closure of mk_closure
+  | Clet of (string * expr) list * expr
+  | Cletrec of (string * letrec_rhs) list * expr
+  | Cif of expr * expr * expr
+  | Cprimop of Primops.op_kind * expr list
+  | Capply of expr * expr list
+
+and mk_closure =
+  { func_name : string
+  ; free_vars : string list
+  }
+
+(* RHS of letrec binding is restricted to certain expr *)
+and letrec_rhs =
+  | Rhs_const of constant
+  | Rhs_mkcls of mk_closure
+
+type closure =
+  { args : string list
+  ; free_vars : string list
+  ; body : expr
+  }
+
+(* A [t] is the closure intermediate representation (CIR) for a whole program. *)
+type t =
+  { funcs : (string, closure) Map.t
+  ; expr : expr
+  }
+
+val from_ast_struct : Ast.structure -> t

--- a/lib/backend/var_namer.ml
+++ b/lib/backend/var_namer.ml
@@ -1,0 +1,117 @@
+open Pervasives
+
+type t =
+  { stamp : int (* for generating unique names *)
+  }
+
+let init =
+  { stamp = 0
+  }
+;;
+
+let gen_new_var_with_prefix t pfx =
+  let name = (String.append pfx (String.append "_" (Int.to_string t.stamp))) in
+  let t = { stamp = t.stamp + 1 } in
+  (t, name)
+;;
+
+
+(* NOTE [_rename_vars_in_X] renames all the variables in [X], and it accumulates
+ * a map from old to new names during the process. *)
+let _rename_vars_in_opt_typed_var t (var_map : (string, string) Map.t)
+    (otv : Ast.opt_typed_var) : (t * (string, string) Map.t * Ast.opt_typed_var) =
+  (* binding always makes a new variable *)
+  let old_name = otv.var in
+  let t, new_name = gen_new_var_with_prefix t old_name in
+  let var_map = Map.add old_name new_name var_map in
+  t, var_map, { otv with var = new_name }
+;;
+
+let rec _rename_vars_in_expr t (var_map : (string, string) Map.t)
+    (expr : Ast.expression) : (t * Ast.expression) =
+  match expr.expr_desc with
+  | Exp_const _ | Exp_ident _  -> (t, expr)
+  | Exp_fun (names, body) ->
+    let t, var_map, rev_names = List.fold_left
+        (fun (t, var_map, rev_names) otv ->
+           let t, var_map, name = _rename_vars_in_opt_typed_var t var_map otv in
+           (t, var_map, name::rev_names))
+        (t, var_map, [])
+        names
+    in
+    let names = List.rev rev_names in
+    let t, body = _rename_vars_in_expr t var_map body in
+    let expr = { expr with expr_desc = Exp_fun (names, body) } in
+    (t, expr)
+  | Exp_if (cnd, thn, els) ->
+    let t, cnd = _rename_vars_in_expr t var_map cnd in
+    let t, thn = _rename_vars_in_expr t var_map thn in
+    let t, els = _rename_vars_in_expr t var_map els in
+    let expr = { expr with expr_desc = Exp_if (cnd, thn, els) } in
+    (t, expr)
+  | Exp_let (rec_flag, bds, body) ->
+    let t, var_map, bds = _rename_vars_in_let_bindings t var_map bds in
+    let t, body = _rename_vars_in_expr t var_map body in
+    let expr = { expr with expr_desc = Exp_let (rec_flag, bds, body) } in
+    (t, expr)
+  | Exp_apply (func, args) -> 
+    let t, func = _rename_vars_in_expr t var_map func in
+    let t, rev_args = List.fold_left
+        (fun (t, rev_args) arg ->
+           let t, arg = _rename_vars_in_expr t var_map arg in
+           (t, arg::rev_args))
+        (t, [])
+        args
+    in
+    let args = List.rev rev_args in
+    let expr = { expr with expr_desc = Exp_apply (func, args) } in
+    (t, expr)
+
+and _rename_vars_in_let_bindings t (var_map : (string, string) Map.t)
+    (bds : Ast.binding list)
+  : (t * (string, string) Map.t * Ast.binding list) =
+
+  let _rename_vars_in_one_binding t (var_map : (string, string) Map.t)
+     (bd : Ast.binding) : (t * (string, string) Map.t * Ast.binding) =
+    let t, var_map, binding_lhs =
+      _rename_vars_in_opt_typed_var t var_map bd.binding_lhs in
+    let t, binding_rhs = _rename_vars_in_expr t var_map bd.binding_rhs in
+    let bd = { Ast.binding_lhs; binding_rhs } in
+    (t, var_map, bd)
+  in
+  let t, var_map, rev_bds = List.fold_left
+      (fun (t, var_map, rev_bds) bd ->
+         let t, var_map, bd = _rename_vars_in_one_binding t var_map bd in
+         (t, var_map, bd::rev_bds))
+      (t, var_map, [])
+      bds
+  in
+  let bds = List.rev rev_bds in
+  (t, var_map, bds)
+;;
+
+let _rename_vars_in_struct_item t (var_map : (string, string) Map.t)
+    (item : Ast.struct_item)
+  : (t * (string, string) Map.t * Ast.struct_item) =
+  match item.struct_item_desc with
+  | Struct_eval expr -> 
+    let (t, expr) = _rename_vars_in_expr t var_map expr in
+    let item = { item with struct_item_desc = Struct_eval expr } in
+    (t, var_map, item)
+  | Struct_bind (rec_flag, bds) ->
+    let (t, var_map, bds) = _rename_vars_in_let_bindings t var_map bds in
+    let item = { item with struct_item_desc = Struct_bind (rec_flag, bds) } in
+    (t, var_map, item)
+;;
+
+let rename_struct t structure =
+  let var_map = Map.empty String.compare in
+  let t, _, rev_struct_items = List.fold_left
+      (fun (t, var_map, rev_struct_items) item ->
+         let t, var_map, item = _rename_vars_in_struct_item t var_map item in
+         (t, var_map, item::rev_struct_items))
+      (t, var_map, [])
+      structure
+  in
+  (t, List.rev rev_struct_items)
+;;

--- a/lib/backend/var_namer.mli
+++ b/lib/backend/var_namer.mli
@@ -1,0 +1,15 @@
+
+(** A [t] represents a "name manager" for normal variables *)
+type t
+
+(** [init] is a bare minimum instance of t. *)
+val init : t
+
+(** [rename_struct t s] returns a new structure where all identifiers are
+    consistenly renamed to some unique name (i.e., binding and usage synch) *)
+val rename_struct : t -> Ast.structure -> (t * Ast.structure)
+
+(** [gen_new_var_with_prefix t prefix] creates a variable name starting with
+    [prefix], and is guaranteed to be unique in a context whose variables have
+    been renamed with [t] *)
+val gen_new_var_with_prefix : t -> string -> (t * string)

--- a/lib/common/pretty.mli
+++ b/lib/common/pretty.mli
@@ -1,6 +1,7 @@
 
-(* functions to format datatypes in frontend to string *)
+(* functions to format datatypes from various parts of the compiler *)
 
+(* Frontend stuff *)
 val pp_token            : Token.t -> string
 val pp_token_desc       : Token.desc -> string
 val pp_ast_structure    : Ast.structure -> string
@@ -14,3 +15,6 @@ val pp_lexer_error      : Errors.lexer_error -> string
 val pp_parser_error     : Errors.parser_error -> string
 val pp_ast_interp_error : Errors.ast_interp_error -> string
 val pp_typer_error      : Errors.typer_error -> string
+
+(* Backend stuff *)
+val pp_cir : Cir.t -> string

--- a/lib/common/primops.ml
+++ b/lib/common/primops.ml
@@ -1,5 +1,7 @@
 open Pervasives
 
+(* NOTE
+ * To add another primop, just modify [all_op_infos] and [get_opstr] *)
 type op_kind =
   | AddInt
   | SubInt
@@ -16,6 +18,17 @@ type op_info =
   }
 
 
+let get_opstr op_kind =
+  match op_kind with
+  | AddInt   -> "+"
+  | SubInt   -> "-"
+  | MulInt   -> "*"
+  | LogicAnd -> "&&"
+  | LogicOr  -> "||"
+  | Equal    -> "="
+  | LtInt    -> "<"
+;;
+
 let all_op_infos =
   let _make_binop_type (lhs : Ast.typ) (rhs : Ast.typ) (out : Ast.typ)
     : Ast.typ =
@@ -29,14 +42,16 @@ let all_op_infos =
   let int_int_bool = _make_binop_type int_typ int_typ bool_typ in
   let bool_bool_bool = _make_binop_type bool_typ bool_typ bool_typ in
 
+  List.map
+    (fun (kind, typ) -> { kind; typ; opstr = get_opstr kind })
   [ 
-    { opstr = "+"; kind = AddInt; typ = int_int_int }
-  ; { opstr = "-";  typ = int_int_int; kind = SubInt }
-  ; { opstr = "*";  typ = int_int_int; kind = MulInt }
-  ; { opstr = "<";  typ = int_int_bool; kind = LtInt }
-  ; { opstr = "||"; typ = bool_bool_bool; kind = LogicOr }
-  ; { opstr = "&&"; typ = bool_bool_bool; kind = LogicAnd }
-  ; { opstr = "=";  typ = _make_binop_type tyvar tyvar bool_typ; kind = Equal }
+    (AddInt, int_int_int);
+    (SubInt, int_int_int);
+    (MulInt, int_int_int);
+    (LtInt, int_int_bool);
+    (LogicOr, bool_bool_bool);
+    (LogicAnd, bool_bool_bool);
+    (Equal, _make_binop_type tyvar tyvar bool_typ);
   ]
 ;;
 

--- a/lib/common/primops.mli
+++ b/lib/common/primops.mli
@@ -32,3 +32,6 @@ val get_type : string -> Ast.typ option
 (** [get_op s] returns the primitive op associated with [s],
     or [None] if [s] is not a primitive op. *)
 val get_kind : string -> op_kind option
+
+(** [get_opstr op_kind] returns the opstr associated with [op_kind]. *)
+val get_opstr : op_kind -> string

--- a/lib/driver.ml
+++ b/lib/driver.ml
@@ -29,3 +29,7 @@ let type_file filepath =
   in
   Result.bind (parse_file filepath) type_ast
 ;;
+
+let cir_file filepath =
+  Result.map Cir.from_ast_struct (type_file filepath)
+;;

--- a/lib/driver.mli
+++ b/lib/driver.mli
@@ -9,3 +9,4 @@ open Pervasives
 val lex_file : string -> (Token.t list, string) result
 val parse_file : string -> (Ast.structure, string) result
 val type_file  : string -> (Ast.structure, string) result
+val cir_file  : string -> (Cir.t, string) result

--- a/test/backend/cir-resources/freevar.expect
+++ b/test/backend/cir-resources/freevar.expect
@@ -1,0 +1,95 @@
+closure <+_23> = {
+  args = (prim_arg_25, prim_arg_24)
+  free_vars = ()
+  body = {
+    (+ prim_arg_25 prim_arg_24)
+  }
+}
+closure <-_20> = {
+  args = (prim_arg_22, prim_arg_21)
+  free_vars = ()
+  body = {
+    (- prim_arg_22 prim_arg_21)
+  }
+}
+closure <*_17> = {
+  args = (prim_arg_19, prim_arg_18)
+  free_vars = ()
+  body = {
+    (* prim_arg_19 prim_arg_18)
+  }
+}
+closure <<_14> = {
+  args = (prim_arg_16, prim_arg_15)
+  free_vars = ()
+  body = {
+    (< prim_arg_16 prim_arg_15)
+  }
+}
+closure <||_11> = {
+  args = (prim_arg_13, prim_arg_12)
+  free_vars = ()
+  body = {
+    (|| prim_arg_13 prim_arg_12)
+  }
+}
+closure <&&_8> = {
+  args = (prim_arg_10, prim_arg_9)
+  free_vars = ()
+  body = {
+    (&& prim_arg_10 prim_arg_9)
+  }
+}
+closure <=_5> = {
+  args = (prim_arg_7, prim_arg_6)
+  free_vars = ()
+  body = {
+    (= prim_arg_7 prim_arg_6)
+  }
+}
+closure <closure_4> = {
+  args = (x)
+  free_vars = (g)
+  body = {
+    (g x)
+  }
+}
+closure <closure_3> = {
+  args = (x)
+  free_vars = (f)
+  body = {
+    (f x)
+  }
+}
+closure <closure_0> = {
+  args = (x, y, z)
+  free_vars = (+)
+  body = {
+    (MK_CLOSURE <closure_1> y +)
+  }
+}
+closure <closure_1> = {
+  args = (x)
+  free_vars = (y, +)
+  body = {
+    (MK_CLOSURE <closure_2> y x +)
+  }
+}
+closure <closure_2> = {
+  args = (a, b, c)
+  free_vars = (y, x, +)
+  body = {
+    (+ (+ x a) y)
+  }
+}
+let + = (MK_CLOSURE <+_23> )
+    - = (MK_CLOSURE <-_20> )
+    * = (MK_CLOSURE <*_17> )
+    < = (MK_CLOSURE <<_14> )
+    || = (MK_CLOSURE <||_11> )
+    && = (MK_CLOSURE <&&_8> )
+    = = (MK_CLOSURE <=_5> )
+in let rec f = (MK_CLOSURE <closure_4> g)
+           g = (MK_CLOSURE <closure_3> f)
+   in let f1 = (MK_CLOSURE <closure_0> +)
+      in 42

--- a/test/backend/cir-resources/freevar.soml
+++ b/test/backend/cir-resources/freevar.soml
@@ -1,0 +1,9 @@
+
+let rec f x = g x
+and g x = f x;;
+
+let f1 x y z =
+  (fun x ->
+     (fun a b c ->
+        x + a + y))
+;;

--- a/test/backend/cir_test.ml
+++ b/test/backend/cir_test.ml
@@ -1,0 +1,29 @@
+open Pervasives
+
+(* [filename] can assume CWD is where this file is *)
+let _get_full_path (filename : string) : string =
+  String.append "../../../test/backend/cir-resources/" filename
+;;
+
+let _check_cir_pp (filepath_no_suffix : string) : unit =
+  let filepath = String.append filepath_no_suffix ".soml" in
+  let result =
+    match Driver.cir_file filepath with
+    | Error msg -> msg
+    | Ok cir -> Pretty.pp_cir cir
+  in
+  let expect_path = String.append filepath_no_suffix ".expect" in
+  let actual_path = String.append filepath_no_suffix ".actual" in
+  Test_aux.check_and_output_str result expect_path actual_path;
+;;
+
+
+let tests = OUnit2.(>:::) "cir_test" [
+
+    OUnit2.(>::) "test_integration" (fun _ ->
+        _check_cir_pp (_get_full_path "freevar")
+      );
+  ]
+
+let _ =
+  OUnit2.run_test_tt_main tests

--- a/test/dune
+++ b/test/dune
@@ -8,6 +8,9 @@
    location_test span_test lexer_test parser_test ast_interp_test typer_test
    substs_test
 
+   ; backend
+   cir_test
+
    ; helper functions
    test_aux
   )


### PR DESCRIPTION
Design and implement Closure Intermediate Representation (CIR).

What it does:
1. Eliminate module; a program is function definitions plus a main expression.
2. Use explicit closure construction to make variable capturing explicit.
3. Uncurrying: applications with insufficient # of args are turned into a function.
4. Manifest primitive ops (they were represented as functions in AST).

What it doesn't do:
1. linearize program into instruction sequence