### PR TITLE
Lir

### DIFF
--- a/lib/backend/label.ml
+++ b/lib/backend/label.ml
@@ -1,0 +1,51 @@
+
+type t = string
+
+(* Uniqueness of created [t] guaranteed by uniqueness of [stamp] *)
+let _create_t (str : string) (stamp : int) : t =
+  String.append (String.append str "_") (Int.to_string stamp)
+;;
+
+(* NOTE this must synch with the assembly label of the externally defined
+ * function. *)
+let create_native (str : string) =
+  String.append str "_$" (* disjoint from normal [t] *)
+;;
+
+
+type manager =
+  { next_stamp : int
+  ; name_cache : (string, t) Map.t
+  }
+
+let init_manager =
+  { next_stamp = 0
+  ; name_cache = Map.empty String.compare
+  }
+;;
+
+let _gen_with_prefix manager (prefix : string) : (manager * t) = 
+  let stamp = manager.next_stamp in
+  let t = _create_t prefix stamp in
+  let next_stamp = stamp + 1 in
+  let manager = { manager with next_stamp } in
+  (manager, t)
+;;
+
+let gen manager prefix = 
+  _gen_with_prefix manager prefix
+;;
+
+let gen_and_bind manager (s : string) : (manager * t) =
+  let manager, t = _gen_with_prefix manager s in
+  let name_cache = Map.add s t manager.name_cache in
+  let manager = { manager with name_cache } in
+  (manager, t)
+;;
+
+let get manager s =
+  Map.get s manager.name_cache
+;;
+
+let to_string t = t
+;;

--- a/lib/backend/label.mli
+++ b/lib/backend/label.mli
@@ -1,0 +1,31 @@
+open Pervasives
+
+(** A [t] represents a label in low level representations *)
+type t
+
+(** A [manager] can generate unique [t] and associate string with [t] *)
+type manager
+
+
+(** An [init_manager] is a bare minimum [manager] *)
+val init_manager : manager
+
+(** [get_or_gen manager s] retrieves the [t] bound to [s].
+    Return [None] if [s] is not bound in [manager]. *)
+val get : manager -> string -> t option
+
+(** [gen manager prefix] generates a unique [t] that starts with [prefix]
+    and won't bind it with any string in output [manager].  
+    ASSUME [prefix] doesn't contain space. *)
+val gen : manager -> string -> (manager * t)
+
+(** [gen_and_bind manager name] is like [gen manager], but output manager
+    binds [name] with the returned [t] *)
+val gen_and_bind : manager -> string -> (manager * t)
+
+(** [create_native name] returns a label for externally defined function.
+    It's guaranteed to be unique if [name] is unique *)
+val create_native : string -> t
+
+(** [to_string t] returns a string representation of [t] *)
+val to_string : t -> string

--- a/lib/backend/lir.ml
+++ b/lib/backend/lir.ml
@@ -1,0 +1,451 @@
+open Pervasives
+
+type op =
+  | Add
+  | Sub
+  | Mul
+
+type expr =
+  | Imm of int                           
+  | Tmp of Temp.t                        
+  | Op of op * expr * expr 
+  | Call of Temp.t * expr list
+  | NativeCall of Label.t * expr list
+  | Mem_alloc of int
+
+type cond =
+  | True
+  | Less of expr * expr
+  | Equal of expr * expr
+
+type instr =
+  | Label of Label.t
+  | Load of expr * Temp.t
+  | LoadMem of expr * Temp.t
+  | Store of expr * expr
+  | Store_label of Label.t * expr
+  | Jump of cond * Label.t
+  | Set of cond * Temp.t
+  | Ret of expr
+
+type func =
+  { name     : Label.t
+  ; args     : Temp.t list
+  ; body     : instr list 
+  }
+
+type prog =
+  { funcs : func list
+  ; entry : instr list
+  }
+
+
+(* Context for translating a Cir funciton, hiding boiler-plate details. *)
+type context =
+  { temp_manager  : Temp.manager
+  ; label_manager : Label.manager
+  ; rev_instrs    : instr list
+  }
+
+let _ctx_init (label_manager : Label.manager) : context = 
+  { temp_manager = Temp.init_manager
+  ; label_manager
+  ; rev_instrs = []
+  }
+;;
+
+(* Some wrappers for convenience *)
+let _ctx_add_instr (ctx : context) (instr : instr) : context =
+  let rev_instrs = instr::ctx.rev_instrs in
+  { ctx with rev_instrs }
+;;
+
+(* Add in order *)
+let _ctx_add_instrs (ctx : context) (instrs : instr list) : context =
+  let rec go rev_instrs instrs_to_add =
+    match instrs_to_add with
+    | [] -> rev_instrs
+    | next_to_add::rest_to_add -> go (next_to_add::rev_instrs) rest_to_add
+  in
+  let rev_instrs = go ctx.rev_instrs instrs in
+  { ctx with rev_instrs }
+;;
+
+let _ctx_get_instrs (ctx : context) : instr list =
+  List.rev ctx.rev_instrs
+;;
+
+let _ctx_get_label (ctx : context) (s : string) : Label.t =
+  match Label.get ctx.label_manager s with
+  | None -> failwith "[Lir._ctx_get_label] Unbound name for label"
+  | Some label -> label
+;;
+
+let _ctx_gen_label (ctx : context) (prefix : string) : (context * Label.t) =
+  let label_manager, label = Label.gen ctx.label_manager prefix in
+  let ctx = { ctx with label_manager } in
+  (ctx, label)
+;;
+
+let _ctx_gen_and_bind_label (ctx : context) (name : string)
+  : (context * Label.t) =
+  let label_manager, label = Label.gen_and_bind ctx.label_manager name in
+  let ctx = { ctx with label_manager } in
+  (ctx, label)
+;;
+
+let _ctx_get_temp (ctx : context) (ident : string) : Temp.t =
+  match Temp.get ctx.temp_manager ident with
+  | None -> failwith "[Lir._ctx_get_label] Unbound identifier"
+  | Some temp -> temp
+;;
+
+let _ctx_gen_temp (ctx : context) : (context * Temp.t) =
+  let temp_manager, temp = Temp.gen ctx.temp_manager in
+  let ctx = { ctx with temp_manager } in
+  (ctx, temp)
+;;
+
+let _ctx_gen_and_bind_temp (ctx : context) (ident : string)
+  : (context * Temp.t) =
+  let temp_manager, temp = Temp.gen_and_bind ctx.temp_manager ident in
+  let ctx = { ctx with temp_manager } in
+  (ctx, temp)
+;;
+
+
+
+(* Some constants *)
+let _word_size = 8 (* A bit brittle, good for now I guess, I hope *)
+and _true_e    = Imm 1
+and _false_e   = Imm 0
+;;
+
+
+(* Translate [ce] and emit instructions into [ctx].
+ * ASSUME [ce] is at tail position. *)
+let rec _transl_cir_expr_tailpos (ctx : context) (ce : Cir.expr) : context =
+  let ctx, e = _transl_cir_expr ctx ce in
+  _ctx_add_instr ctx (Ret e)
+
+and _transl_cir_expr (ctx : context) (ce : Cir.expr) : (context * expr) =
+  match ce with
+  | Cconst const            -> (ctx, _transl_cir_const const)
+  | Cident name             -> (ctx, Tmp (_ctx_get_temp ctx name))
+  | Cmk_closure mkcls       -> _transl_cir_mk_closure ctx mkcls
+  | Cprimop (op_kind, args) -> _transl_cir_primop ctx op_kind args
+  | Cif (cnd, thn, els)     -> _transl_cir_if ctx cnd thn els
+  | Capply (func, args)     -> _transl_cir_apply ctx func args
+
+  | Clet (bds, body) ->
+    let ctx = _transl_cir_let_bindings ctx bds in
+    _transl_cir_expr ctx body
+
+  | Cletrec (bds, body) ->
+    let ctx = _transl_cir_letrec_bindings ctx bds in
+    _transl_cir_expr ctx body
+
+and _transl_cir_const (const : Cir.constant) : expr =
+  match const with
+  | CInt n      -> Imm (n * 2 + 1) (* NOTE synch with C runtime *)
+  | CBool true  -> _true_e
+  | CBool false -> _false_e
+
+and _transl_cir_primop (ctx : context)
+    (op_kind : Primops.op_kind) (args : Cir.expr list)
+  : (context * expr) =
+  let lhs_ce, rhs_ce = match args with
+    | lhs_ce::[rhs_ce] -> lhs_ce, rhs_ce
+    | _ -> failwith "[Lir._transl_cir_primop] invalid # of args for primop"
+  in
+
+  (* can't evaluate both due to potential short-circuiting *)
+  let ctx, lhs_e = _transl_cir_expr ctx lhs_ce in 
+  match op_kind with
+  (* NOTE there are small optimizations
+   * synch with representations defined in [_transl_cir_const] *)
+  | AddInt ->
+    let ctx, rhs_e = _transl_cir_expr ctx rhs_ce in
+    (* (2a + 1) + (2b + 1) = 2(a+b) + 2 = (2(a+b) + 1) + 1 *)
+    (ctx, Op (Sub, (Op (Add, lhs_e, rhs_e)), Imm 1))
+
+  | SubInt ->
+    let ctx, rhs_e = _transl_cir_expr ctx rhs_ce in
+    (* (2a + 1) - (2b + 1) = 2(a-b) = (2(a+b) - 1) + 1 *)
+    (ctx, Op (Add, (Op (Add, lhs_e, rhs_e)), Imm 1))
+
+  | MulInt ->
+    let ctx, rhs_e = _transl_cir_expr ctx rhs_ce in
+    (* (2a + 1) * (2b + 1) = 4(a*b) + 2(a+b) + 2 = 4(a*b) + 1 + (2(a+b) + 1) *)
+    let lhs_add_rhs = Op (Add, lhs_e, rhs_e) in
+    let extra = Op (Add, Imm 1, (Op (Mul, Imm 2, lhs_add_rhs))) in
+    let lhs_mul_rhs = Op (Mul, lhs_e, rhs_e) in
+    (ctx, Op (Sub, lhs_mul_rhs, extra))
+
+  (* TODO could optimize And/Or if it's in an if condition -- jump straight
+   * to corresponding branch when short-circuiting *)
+  | LogicAnd ->
+    _transl_binop_with_short_circuit ctx lhs_e rhs_ce _false_e "and"
+
+  | LogicOr ->
+    _transl_binop_with_short_circuit ctx lhs_e rhs_ce _true_e "or"
+
+  | Equal ->
+    let ctx, rhs_e = _transl_cir_expr ctx rhs_ce in
+    (* NOTE this label must synch with the external function name *)
+    let label = Label.create_native "equal" in
+    let call_e = NativeCall (label, [lhs_e; rhs_e]) in
+    (ctx, call_e)
+
+  | LtInt ->
+    let ctx, rhs_e = _transl_cir_expr ctx rhs_ce in
+    let ctx, result_temp = _ctx_gen_temp ctx in
+    let set_instr = Set (Less (lhs_e, rhs_e), result_temp) in
+    let ctx = _ctx_add_instr ctx set_instr in
+    (ctx, Tmp result_temp)
+    
+(* Macro to help codegen:
+ *
+ * if lhs = {value} jump to {prefix}-short-circuit
+ * [...translate rhs...]
+ * result_temp := rhs_expr
+ * jump to {prefix}-end
+ *
+ * {prefix}-short-circuit:
+ * result_temp := {value}
+ *
+ * {prefix}-end: ... *)
+and _transl_binop_with_short_circuit
+    (ctx : context) (lhs_e : expr) (rhs_ce : Cir.expr)
+    (value : expr) (prefix : string)
+  : (context * expr) =
+  let ctx, short_circuit_label =
+    _ctx_gen_label ctx (String.append prefix "_short_circuit") in
+  let ctx, end_label = _ctx_gen_label ctx (String.append prefix "_end") in
+  let ctx, result_temp = _ctx_gen_temp ctx in
+  let lhs_eq_value_e = Equal (lhs_e, value) in
+  let ctx = _ctx_add_instr ctx (Jump (lhs_eq_value_e, short_circuit_label)) in
+  let ctx, rhs_e = _transl_cir_expr ctx rhs_ce in
+  let ctx = _ctx_add_instrs ctx [ Load (rhs_e, result_temp);
+                                  Jump (True, end_label);
+                                  Label short_circuit_label;
+                                  Load (value, result_temp);
+                                  Label end_label; ]
+  in
+  (ctx, Tmp result_temp)
+
+(* [...translate cnd...]
+ * If cond_expr = 0 jump to false
+ * [...translate thn...]
+ * result_temp := thn_expr
+ * jump to end
+ *
+ * false:
+ * [...translate els...]
+ * result_temp := els_expr
+ *
+ * end: ...
+ *)
+and _transl_cir_if
+    (ctx : context) (cnd_ce : Cir.expr) (thn_ce : Cir.expr) (els_ce : Cir.expr)
+  : (context * expr) =
+  let ctx, result_temp = _ctx_gen_temp ctx in
+  let ctx, false_label = _ctx_gen_label ctx "if_false" in
+  let ctx, end_label = _ctx_gen_label ctx "if_end" in
+  let ctx, cnd_e = _transl_cir_expr ctx cnd_ce in
+  let cond_eq_false_e = Equal (cnd_e, _false_e) in
+  let ctx = _ctx_add_instr ctx (Jump (cond_eq_false_e, false_label)) in
+  let ctx, thn_e = _transl_cir_expr ctx thn_ce in
+  let ctx = _ctx_add_instr ctx (Load (thn_e, result_temp)) in
+  let ctx = _ctx_add_instr ctx (Jump (cond_eq_false_e, end_label)) in
+  let ctx = _ctx_add_instr ctx (Label false_label) in
+  let ctx, els_e = _transl_cir_expr ctx els_ce in
+  let ctx = _ctx_add_instr ctx (Load (els_e, result_temp)) in
+  let ctx = _ctx_add_instr ctx (Label end_label) in
+  (ctx, Tmp result_temp)
+
+(* NOTE must synch up with [_emit_cls_prelude]
+ *
+ * [...translate func_ce...]
+ * [...translate arg_cen...]
+ * label_temp := *[func_e]
+ * Call(label_temp, [func_e; arg_e0; ... arg_en])
+ *)
+and _transl_cir_apply
+    (ctx : context) (func_ce : Cir.expr) (arg_ces : Cir.expr list)
+  : (context * expr) =
+  let ctx, func_e = _transl_cir_expr ctx func_ce in
+  let ctx, arg_es = (* NOTE technically the order can be arbitrary :) *)
+    List.fold_left 
+      (fun (ctx, rev_arg_es) arg_ce ->
+         let ctx, arg_e = _transl_cir_expr ctx arg_ce in
+         (ctx, arg_e::rev_arg_es))
+      (ctx, []) arg_ces
+    |> (fun (ctx, rev_arg_es) -> (ctx, List.rev rev_arg_es))
+  in
+  let ctx, label_temp = _ctx_gen_temp ctx in
+  let ctx = _ctx_add_instr ctx (LoadMem (func_e, label_temp)) in
+  let call_e = Call (label_temp, func_e::arg_es) in
+  (ctx, call_e)
+
+(* [...translate bd_rhs_0...]
+ * result_temp_0 := bd_rhs_0
+ * ...
+ * [...translate bd_rhs_n...]
+ * result_temp_n := bd_rhs_n
+ *)
+and _transl_cir_let_bindings
+    (ctx : context) (bds : (string * Cir.expr) list)
+  : context =
+  List.fold_left 
+    (fun ctx (lhs_name, rhs_ce) ->
+       let ctx, result_temp = _ctx_gen_and_bind_temp ctx lhs_name in
+       let ctx, rhs_e = _transl_cir_expr ctx rhs_ce in
+       _ctx_add_instr ctx (Load (rhs_e, result_temp)))
+    ctx bds
+
+(* [...translate bd_rhs_0 by allocating space only...]
+ * result_temp_0 := bd_rhs_0
+ * ...
+ * [...translate bd_rhs_n by allocating space only...]
+ * result_temp_n := bd_rhs_n
+ * [...finish translating bd_rhs_0...]
+ * ...
+ * [...finish translating bd_rhs_n...]
+ *)
+and _transl_cir_letrec_bindings
+    (ctx : context) (bds : (string * Cir.letrec_rhs) list)
+  : context =
+  let ctx, (addr_rhs_pairs : (expr * Cir.letrec_rhs) list)  =
+    List.fold_left 
+      (fun (ctx, rev_addr_rhs_pairs) (lhs_name, rhs_ce) ->
+         let ctx, result_temp = _ctx_gen_and_bind_temp ctx lhs_name in
+         let addr_e = _transl_cir_letrec_rhs_alloc_space rhs_ce in
+         let ctx = _ctx_add_instr ctx (Load (addr_e, result_temp)) in
+         let pair = (Tmp result_temp, rhs_ce) in
+         (ctx, pair::rev_addr_rhs_pairs))
+      (ctx, []) bds
+  |> (fun (ctx, rev_addr_rhs_pairs) -> (ctx, List.rev rev_addr_rhs_pairs))
+  in 
+  List.fold_left
+    (fun ctx (addr_e, rhs_ce) ->
+       let ctx, _ = _transl_cir_letrec_rhs_skip_alloc ctx addr_e rhs_ce in
+       ctx)
+    ctx addr_rhs_pairs
+
+and _transl_cir_letrec_rhs_alloc_space (rhs_ce : Cir.letrec_rhs) : expr =
+  match rhs_ce with
+  | Rhs_const const -> _transl_cir_const const
+  | Rhs_mkcls mkcls -> _transl_cir_mkcls_alloc_space mkcls.free_vars
+
+and _transl_cir_letrec_rhs_skip_alloc
+    (ctx : context) (addr_e : expr) (rhs_ce : Cir.letrec_rhs)
+  : (context * expr) =
+  match rhs_ce with
+  | Rhs_const _ -> (ctx, addr_e) (* unboxed value needs no extra space *)
+  | Rhs_mkcls mkcls -> _transl_cir_mkcls_skip_alloc ctx addr_e mkcls
+
+(* ++++++++++++++++++++++++++++++++++++++++++++++++++++
+ * | entry label | first freevar | ... | last freevar |
+ * ++++++++++++++++++++++++++++++++++++++++++++++++++++
+ * Each slot takes up a word size
+ * NOTE must synch up with [_emit_cls_prelude] *)
+and _transl_cir_mkcls_alloc_space (free_vars : string list) : expr =
+  let slots = 1 + (List.length free_vars) in
+  Mem_alloc slots
+
+and _transl_cir_mkcls_skip_alloc (ctx : context)
+    (cls_addr_e : expr) (mkcls : Cir.mk_closure)
+  : (context * expr) =
+  let entry_label = _ctx_get_label ctx mkcls.func_name in
+  let ctx = _ctx_add_instr ctx (Store_label (entry_label, cls_addr_e)) in
+  let ctx, _ =
+    List.fold_left (* store each free variable to their slot *)
+      (fun (ctx, word_offset) fv_name ->
+         let fv_e = Tmp (_ctx_get_temp ctx fv_name) in
+         let slot_addr_e =
+           Op (Add, cls_addr_e, Imm (word_offset * _word_size)) in
+         let ctx = _ctx_add_instr ctx (Store (fv_e, slot_addr_e)) in
+         (ctx, word_offset + 1))
+      (ctx, 1)
+      mkcls.free_vars
+  in
+  (ctx, cls_addr_e)
+
+and _transl_cir_mk_closure (ctx : context) (mkcls : Cir.mk_closure)
+  : (context * expr) =
+  let space_alloc_e = _transl_cir_mkcls_alloc_space mkcls.free_vars in
+  let ctx, cls_addr_temp = _ctx_gen_temp ctx in
+  let ctx = _ctx_add_instr ctx (Load (space_alloc_e, cls_addr_temp)) in
+  let cls_addr_e = Tmp cls_addr_temp in
+  _transl_cir_mkcls_skip_alloc ctx cls_addr_e mkcls
+;;
+
+
+(* Generate temps for args; load closure free variables into temps.
+ * Return an list of temps for arguments __in order__.
+ * NOTE
+ * - Must be used at beginning of a closure translation. 
+ * - Must synch up [_transl_cir_apply] and [_transl_cir_mk_closure]. *)
+let _emit_cls_prelude (ctx : context) (cls : Cir.closure)
+  : (context * Temp.t list) =
+  let ctx, cls_temp = _ctx_gen_temp ctx in
+  let ctx, arg_temps =
+    List.fold_right (* order matters *)
+      (fun arg_name (ctx, arg_temps) ->
+         let ctx, arg_temp = _ctx_gen_and_bind_temp ctx arg_name in
+         (ctx, arg_temp::arg_temps))
+      cls.args
+      (ctx, [])
+  in
+  let ctx, _ = (* emit code for loading freevars *)
+    List.fold_left
+      (fun (ctx, word_offset) fv_name ->
+         (* fv_temp = *[cls_temp + word_offset] *)
+         let ctx, fv_temp = _ctx_gen_and_bind_temp ctx fv_name in
+         let slot_addr_e = Op (Add, Tmp cls_temp, Imm word_offset) in
+         let load_instr = LoadMem (slot_addr_e, fv_temp) in
+         let ctx = _ctx_add_instr ctx load_instr in
+         (ctx ,word_offset + 1))
+      (ctx, 1) (* offset 0 is entry label *)
+      cls.free_vars
+  in
+  (ctx, cls_temp::arg_temps)
+;;
+  
+
+(* ASSUME each func name from the Cir program is bound in [label_manager] *)
+let _from_closure
+    (label_manager : Label.manager) (name : string) (cls : Cir.closure)
+  : (Label.manager * func) =
+  let ctx = _ctx_init label_manager in
+  let entry_label = _ctx_get_label ctx name in
+  let ctx, arg_temps = _emit_cls_prelude ctx cls in
+  let ctx = _transl_cir_expr_tailpos ctx cls.body in
+  let body = _ctx_get_instrs ctx in
+  let func = { name = entry_label; args = arg_temps; body } in
+  (ctx.label_manager, func)
+;;
+
+let from_cir_prog (cir_prog : Cir.prog) =
+  let label_manager = Label.init_manager in
+  (* Scope of each function name is the entire program *)
+  let label_manager =
+    Map.foldi
+      (fun name _ label_manager ->
+         let label_manager, _ = Label.gen_and_bind label_manager name in
+         label_manager)
+      cir_prog.funcs label_manager
+  in
+  let label_manager, funcs =
+    Map.foldi
+      (fun name cls (label_manager, funcs) ->
+         let label_manager, func = _from_closure label_manager name cls in
+         (label_manager, func::funcs))
+      cir_prog.funcs (label_manager, [])
+  in
+  let ctx = _ctx_init label_manager in
+  let ctx = _transl_cir_expr_tailpos ctx cir_prog.expr in
+  let entry = _ctx_get_instrs ctx in
+  { funcs; entry }
+;;

--- a/lib/backend/lir.mli
+++ b/lib/backend/lir.mli
@@ -1,0 +1,64 @@
+open Pervasives
+
+type op =
+  | Add
+  | Sub
+  | Mul
+
+(* NOTE interpretation is up to instructions (as address or plain value).*)
+type expr =
+  | Imm of int             (* numerical constant *)
+  | Tmp of Temp.t          (* temporary register *)
+  | Op of op * expr * expr (* Binary operation *)
+  | Call of Temp.t * expr list
+      (* Call (func, args) --> func(args) *)
+  | NativeCall of Label.t * expr list
+      (* NativeCall (label, args) --> label(args) *)
+  | Mem_alloc of int
+      (* Mem_alloc (n_bytes) --> dynamic_mem_alloc(n_bytes) *)
+
+(** A [cond] is a conditional expression used for control flow *)
+type cond =
+  | True
+  | Less of expr * expr
+  | Equal of expr * expr
+
+(** An [instr] is a basic building block of Lir. *)
+type instr =
+  | Label of Label.t
+  | Load of expr * Temp.t
+      (* Load (e, temp) --> temp := e *)
+  | LoadMem of expr * Temp.t
+      (* LoadMem (e, temp) --> temp := *[e] *)
+  | Store of expr * expr
+      (* Store (e, dst_addr) --> *[dst_addr] := e *)
+  | Store_label of Label.t * expr
+      (* Store_label (label, dst_addr) --> *[dst_addr] := label *)
+  | Jump of cond * Label.t
+      (* Jump to label if [cond] is satisfied. *)
+  | Set of cond * Temp.t
+      (* Sets content of [temp] to 0 if [cond] is satisfied, else 1 *)
+  | Ret of expr
+      (* Return the result of [expr] to callee function *)
+
+
+(** A [func] is a function at Lir level. *)
+type func =
+  { name     : Label.t
+  ; args     : Temp.t list
+  ; body     : instr list     (* always starts with [name] label *)
+  }
+
+
+(** A [prog] is the entire program at Lir level. *)
+type prog =
+  { funcs : func list
+  ; entry : instr list
+  }
+
+
+(** [from_cir_prog cir] translates a program in Cir to Lir. 
+    ASSUME: All names (label or variable) are bound.
+    UNDEFINED BEHAVIOR if name bindings are not unique in respective namespaces.
+*)
+val from_cir_prog : Cir.prog -> prog

--- a/lib/backend/temp.ml
+++ b/lib/backend/temp.ml
@@ -1,0 +1,43 @@
+
+type t = int
+
+let _init_t = 0
+;;
+
+let _get_next_t t =
+  t + 1
+;;
+
+
+type manager =
+  { next_t     : t
+  ; name_cache : (string, t) Map.t
+  }
+
+let init_manager =
+  { next_t     = _init_t
+  ; name_cache = Map.empty String.compare
+  }
+;;
+
+let gen manager = 
+  let t = manager.next_t in
+  let next_t = _get_next_t t in
+  let manager = { manager with next_t } in
+  (manager, t)
+;;
+
+let gen_and_bind manager (s : string) : (manager * t) =
+  let manager, t = gen manager in
+  let name_cache = Map.add s t manager.name_cache in
+  let manager = { manager with name_cache } in
+  (manager, t)
+;;
+
+let get manager s =
+  Map.get s manager.name_cache
+;;
+
+let to_string t =
+  String.append "T" (Int.to_string t)
+;;

--- a/lib/backend/temp.mli
+++ b/lib/backend/temp.mli
@@ -1,0 +1,26 @@
+open Pervasives
+
+(** A [t] represents some temporary register *)
+type t
+
+(** A [manager] can generate unique [t] and associate string with [t] *)
+type manager
+
+
+(** An [init_manager] is a bare minimum [manager] *)
+val init_manager : manager
+
+(** [get_or_gen manager s] retrieves the [t] bound to [s].
+    Return [None] if [s] is not bound in [manager]. *)
+val get : manager -> string -> t option
+
+(** [gen manager] generates a unique [t] and won't bind it with any string
+    in output [manager] *)
+val gen : manager -> (manager * t)
+
+(** [gen_and_bind manager name] is like [gen manager], but output manager
+    binds [name] with the returned [t] *)
+val gen_and_bind : manager -> string -> (manager * t)
+
+(** [to_string t] returns a string representation of [t] *)
+val to_string : t -> string

--- a/lib/common/pretty.mli
+++ b/lib/common/pretty.mli
@@ -18,3 +18,4 @@ val pp_typer_error      : Errors.typer_error -> string
 
 (* Backend stuff *)
 val pp_cir : Cir.prog -> string
+val pp_lir_prog : Lir.prog -> string

--- a/lib/driver.ml
+++ b/lib/driver.ml
@@ -33,3 +33,7 @@ let type_file filepath =
 let cir_file filepath =
   Result.map Cir.from_ast_struct (type_file filepath)
 ;;
+
+let lir_file filepath =
+  Result.map Lir.from_cir_prog (cir_file filepath)
+;;

--- a/lib/driver.mli
+++ b/lib/driver.mli
@@ -10,3 +10,4 @@ val lex_file : string -> (Token.t list, string) result
 val parse_file : string -> (Ast.structure, string) result
 val type_file  : string -> (Ast.structure, string) result
 val cir_file  : string -> (Cir.prog, string) result
+val lir_file  : string -> (Lir.prog, string) result

--- a/test/backend/label_test.ml
+++ b/test/backend/label_test.ml
@@ -1,0 +1,57 @@
+
+open Pervasives
+
+let tests = OUnit2.(>:::) "label_test" [
+
+    (* NOTE as long as [to_string] uniquely distinguishes labels, we don't care
+     * what it actually returns *)
+    OUnit2.(>::) "test_gen" (fun _ ->
+        let manager = Label.init_manager in
+        let manager, t1 = Label.gen manager "s1" in
+        let manager, t2 = Label.gen manager "s1" in
+        let _, t3 = Label.gen manager "s2" in
+        OUnit2.assert_equal false ((Label.to_string t1) = (Label.to_string t2));
+        OUnit2.assert_equal false ((Label.to_string t2) = (Label.to_string t3));
+        OUnit2.assert_equal false ((Label.to_string t3) = (Label.to_string t1));
+      );
+
+    OUnit2.(>::) "test_create_native" (fun _ ->
+        let manager = Label.init_manager in
+        let manager, t1 = Label.gen manager "s1" in
+        let _, t2 = Label.gen_and_bind manager "s1" in
+        let foo_t = Label.create_native "foo" in
+        let bar_t = Label.create_native "bar" in
+        OUnit2.assert_equal false ((Label.to_string t1) = (Label.to_string foo_t));
+        OUnit2.assert_equal false ((Label.to_string t2) = (Label.to_string foo_t));
+        OUnit2.assert_equal false ((Label.to_string t1) = (Label.to_string bar_t));
+        OUnit2.assert_equal false ((Label.to_string t2) = (Label.to_string bar_t));
+        OUnit2.assert_equal false ((Label.to_string foo_t) = (Label.to_string bar_t));
+      );
+
+    (* test with [get] together *)
+    OUnit2.(>::) "test_gen_and_bind" (fun _ ->
+        let manager = Label.init_manager in
+        let s1, s2 = "s1", "s2" in
+        let manager, t1 = Label.gen_and_bind manager s1 in
+        let manager, t2 = Label.gen_and_bind manager s2 in
+        let manager, t3 = Label.gen manager "s1" in
+        let manager, t4 = Label.gen manager "s2" in
+        OUnit2.assert_equal false ((Label.to_string t1) = (Label.to_string t2));
+        OUnit2.assert_equal false ((Label.to_string t2) = (Label.to_string t3));
+        OUnit2.assert_equal false ((Label.to_string t3) = (Label.to_string t4));
+        OUnit2.assert_equal false ((Label.to_string t4) = (Label.to_string t1));
+        OUnit2.assert_equal false ((Label.to_string t3) = (Label.to_string t2));
+        OUnit2.assert_equal false ((Label.to_string t4) = (Label.to_string t2));
+        let t1' = Label.get manager s1 in
+        let t2' = Label.get manager s2 in
+        OUnit2.assert_equal
+          (Some (Label.to_string t1))
+          (Option.map Label.to_string t1');
+        OUnit2.assert_equal
+          (Some (Label.to_string t2))
+          (Option.map Label.to_string t2');
+      );
+  ]
+
+let _ =
+  OUnit2.run_test_tt_main tests

--- a/test/backend/temp_test.ml
+++ b/test/backend/temp_test.ml
@@ -1,0 +1,43 @@
+open Pervasives
+
+let tests = OUnit2.(>:::) "temp_test" [
+
+    (* NOTE as long as [to_string] uniquely distinguishes temps, we don't care
+     * what it actually returns *)
+    OUnit2.(>::) "test_gen" (fun _ ->
+        let manager = Temp.init_manager in
+        let manager, t1 = Temp.gen manager in
+        let manager, t2 = Temp.gen manager in
+        let _, t3 = Temp.gen manager in
+        OUnit2.assert_equal false ((Temp.to_string t1) = (Temp.to_string t2));
+        OUnit2.assert_equal false ((Temp.to_string t2) = (Temp.to_string t3));
+        OUnit2.assert_equal false ((Temp.to_string t3) = (Temp.to_string t1));
+      );
+
+    (* test with [get] together *)
+    OUnit2.(>::) "test_gen_and_bind" (fun _ ->
+        let manager = Temp.init_manager in
+        let s1, s2 = "s1", "s2" in
+        let manager, t1 = Temp.gen_and_bind manager s1 in
+        let manager, t2 = Temp.gen_and_bind manager s2 in
+        let manager, t3 = Temp.gen manager in
+        let manager, t4 = Temp.gen manager in
+        OUnit2.assert_equal false ((Temp.to_string t1) = (Temp.to_string t2));
+        OUnit2.assert_equal false ((Temp.to_string t2) = (Temp.to_string t3));
+        OUnit2.assert_equal false ((Temp.to_string t3) = (Temp.to_string t4));
+        OUnit2.assert_equal false ((Temp.to_string t4) = (Temp.to_string t1));
+        OUnit2.assert_equal false ((Temp.to_string t3) = (Temp.to_string t2));
+        OUnit2.assert_equal false ((Temp.to_string t4) = (Temp.to_string t2));
+        let t1' = Temp.get manager s1 in
+        let t2' = Temp.get manager s2 in
+        OUnit2.assert_equal
+          (Some (Temp.to_string t1))
+          (Option.map Temp.to_string t1');
+        OUnit2.assert_equal
+          (Some (Temp.to_string t2))
+          (Option.map Temp.to_string t2');
+      );
+  ]
+
+let _ =
+  OUnit2.run_test_tt_main tests

--- a/test/dune
+++ b/test/dune
@@ -9,7 +9,7 @@
    substs_test
 
    ; backend
-   cir_test
+   cir_test temp_test
 
    ; helper functions
    test_aux

--- a/test/dune
+++ b/test/dune
@@ -9,7 +9,7 @@
    substs_test
 
    ; backend
-   cir_test temp_test
+   cir_test temp_test label_test
 
    ; helper functions
    test_aux


### PR DESCRIPTION
Add in another, more low-level IR (hence the name LIR)

## High level goals
1. Closer to machine instructions (removing more high-level concepts like
   primop, conditional, letrec, closure creation, etc.)
2. Creates room for instruction selection (doesn't seem to be useful though, for this functional language).
3. Agnostic to 
  - memory layout, e.g., stack and heap.
  - calling convention
  - register set
4. Determines memory representation of different types of data.
5. Determines word size.

## Testing

I don't think it's terribly helpful to test Lir, or I just don't see a good way of testing it.
I implemented pretty-printing to help debugging later, but from this point on I'll stick with executable as compiler integration test.

