### PR TITLE
X86 backend (without register allocation and final assembly generation)

### DIFF
--- a/lib/backend/constants.ml
+++ b/lib/backend/constants.ml
@@ -1,0 +1,18 @@
+
+(* This module contains some constants for runtime and backend *)
+
+
+(** Word size in bytes for runtime and backend *)
+let word_size = 8
+;;
+
+
+(* The followings should be used as native labels *)
+
+(** dynamic memory allocation *)
+let mem_alloc_name = "mem_alloc"
+;;
+
+(** program entry *)
+let entry_name = "entry"
+;;

--- a/lib/backend/label.mli
+++ b/lib/backend/label.mli
@@ -23,9 +23,11 @@ val gen : manager -> string -> (manager * t)
     binds [name] with the returned [t] *)
 val gen_and_bind : manager -> string -> (manager * t)
 
-(** [create_native name] returns a label for externally defined function.
+(** [get_native name] returns a label for externally defined function.
     It's guaranteed to be unique if [name] is unique *)
-val create_native : string -> t
+val get_native : string -> t
+
+val to_epilogue : t -> t
 
 (** [to_string t] returns a string representation of [t] *)
 val to_string : t -> string

--- a/lib/backend/lir.ml
+++ b/lib/backend/lir.ml
@@ -118,8 +118,7 @@ let _ctx_gen_and_bind_temp (ctx : context) (ident : string)
 
 
 (* Some constants *)
-let _word_size = 8 (* A bit brittle, good for now I guess, I hope *)
-and _true_e    = Imm 1
+let _true_e    = Imm 1
 and _false_e   = Imm 0
 ;;
 
@@ -372,7 +371,7 @@ and _transl_cir_mkcls_skip_alloc (ctx : context)
          let word_offset = n + 1 in (* start at 1 *)
          let fv_e = Tmp (_ctx_get_temp ctx fv_name) in
          let slot_addr_e =
-           Op (Add, cls_addr_e, Imm (word_offset * _word_size)) in
+           Op (Add, cls_addr_e, Imm (word_offset * Constants.word_size)) in
          Store (fv_e, slot_addr_e))
       mkcls.free_vars
   in

--- a/lib/backend/lir.ml
+++ b/lib/backend/lir.ml
@@ -29,14 +29,16 @@ type instr =
   | Ret of expr
 
 type func =
-  { name     : Label.t
-  ; args     : Temp.t list
-  ; body     : instr list 
+  { name         : Label.t
+  ; ordered_args : Temp.t list
+  ; body         : instr list 
+  ; temp_manager : Temp.manager
   }
 
 type prog =
   { funcs : func list
   ; entry : instr list
+  ; temp_manager  : Temp.manager
   }
 
 
@@ -428,7 +430,10 @@ let _from_closure
   let ctx, arg_temps = _emit_cls_prelude ctx cls in
   let ctx = _transl_cir_expr_tailpos ctx cls.body in
   let body = _ctx_get_instrs ctx in
-  let func = { name = entry_label; args = arg_temps; body } in
+  let temp_manager = ctx.temp_manager in
+  let func =
+    { name = entry_label; ordered_args = arg_temps; body; temp_manager }
+  in
   (ctx.label_manager, func)
 ;;
 
@@ -451,6 +456,7 @@ let from_cir_prog (cir_prog : Cir.prog) =
   in
   let ctx = _ctx_init label_manager in
   let ctx = _transl_cir_expr_tailpos ctx cir_prog.expr in
-  let entry = _ctx_get_instrs ctx in
-  { funcs; entry }
+  { funcs
+  ; entry = _ctx_get_instrs ctx
+  ; temp_manager = ctx.temp_manager }
 ;;

--- a/lib/backend/lir.ml
+++ b/lib/backend/lir.ml
@@ -278,7 +278,7 @@ and _transl_cir_apply
 and _transl_cir_native_apply
     (ctx : context) (name : string) (arg_ces : Cir.expr list)
   : (context * expr) =
-  let native_label = Label.create_native name in
+  let native_label = Label.get_native name in
   let ctx, arg_es = _transl_cir_apply_args ctx arg_ces in
   let call_e = NativeCall (native_label, arg_es) in
   (ctx, call_e)

--- a/lib/backend/lir.mli
+++ b/lib/backend/lir.mli
@@ -37,23 +37,25 @@ type instr =
   | Jump of cond * Label.t
       (* Jump to label if [cond] is satisfied. *)
   | Set of cond * Temp.t
-      (* Sets content of [temp] to 0 if [cond] is satisfied, else 1 *)
+      (* Sets content of [temp] to 1 if [cond] is satisfied, else 0 *)
   | Ret of expr
       (* Return the result of [expr] to callee function *)
 
 
 (** A [func] is a function at Lir level. *)
 type func =
-  { name     : Label.t
-  ; args     : Temp.t list
-  ; body     : instr list  (* NOTE doesn't start with [name] label *)
+  { name         : Label.t
+  ; ordered_args : Temp.t list  (* 1st temp for 1st function arg, etc. *)
+  ; body         : instr list   (* NOTE doesn't start with [name] label *)
+  ; temp_manager : Temp.manager
   }
 
 
 (** A [prog] is the entire program at Lir level. *)
 type prog =
-  { funcs : func list
-  ; entry : instr list
+  { funcs         : func list
+  ; entry         : instr list   (* no entry label, to be generated later *)
+  ; temp_manager  : Temp.manager (* for [entry] *)
   }
 
 

--- a/lib/backend/x86.ml
+++ b/lib/backend/x86.ml
@@ -1,0 +1,348 @@
+open Pervasives
+
+type physical_reg =
+  | Rax
+  | Rbx
+  | Rsi
+  | Rdi
+  | Rdx
+  | Rcx
+  | R8
+  | R9
+  | R10
+  | R11
+  | R12
+  | R13
+  | R14
+  | R15
+
+let ordered_argument_physical_regs =
+  [Rdi; Rsi; Rdx; Rcx; R8; R9]
+;;
+
+type 'a reg =
+  | Rsp        
+  | Rbp        
+  | Greg of 'a 
+
+type 'a arg =
+  | Lbl_arg of Label.t
+  | Imm_arg of int
+  | Reg_arg of 'a reg
+  | Mem_arg of 'a reg * int
+
+type cond =
+  | Eq
+  | Lt
+
+type binop =
+  | Add
+  | Sub
+  | Mul
+
+type 'a instr = 
+  | Label of Label.t
+  | Load of 'a arg * 'a reg
+  | Store of 'a arg * 'a reg * int
+  | Push of 'a
+  | Pop of 'a
+  | Binop of binop * 'a * 'a arg
+  | Cmp of 'a arg * 'a
+  | Jmp of Label.t
+  | JmpC of cond * Label.t
+  | Call_reg of 'a
+  | Call_lbl of Label.t
+  | SetC of cond * 'a
+  | Ret
+
+type func =
+  { entry  : Label.t
+  ; instrs : physical_reg instr list
+  }
+
+type prog = 
+  { funcs : func list
+  ; main : func
+  }
+
+type temp_func = 
+  { entry  : Label.t
+  ; instrs : Temp.t instr list
+  ; args   : Temp.t list
+  ; rax    : Temp.t
+  }
+
+type temp_prog = 
+  { temp_funcs : temp_func list
+  ; temp_main  : temp_func
+  }
+
+
+let _word_size = 8
+;;
+
+
+type context =
+  { func_label        : Label.t
+  ; rax_temp          : Temp.t
+  ; ordered_arg_temps : Temp.t list
+  (* following are "mutable" *)
+  ; temp_manager      : Temp.manager
+  ; rev_instrs        : Temp.t instr list
+  }
+
+let _init_ctx
+    (func_label : Label.t) (ordered_arg_temps : Temp.t list)
+    (temp_manager : Temp.manager)
+  : context =
+  let temp_manager, rax_temp = Temp.gen temp_manager in
+  { func_label; rax_temp; ordered_arg_temps;
+    temp_manager; rev_instrs = [] }
+;;
+
+let _ctx_add_instr (ctx : context) (instr : Temp.t instr) : context =
+  let rev_instrs = instr::ctx.rev_instrs in
+  { ctx with rev_instrs }
+;;
+
+let _ctx_get_instrs (ctx : context) : Temp.t instr list =
+  List.rev ctx.rev_instrs
+;;
+
+let _ctx_gen_temp (ctx : context) : (context * Temp.t)  =
+  let temp_manager, temp = Temp.gen ctx.temp_manager in
+  ({ ctx with temp_manager }, temp)
+;;
+
+let _ctx_get_epilogue_label (ctx : context) : Label.t =
+  Label.to_epilogue ctx.func_label
+;;
+
+(* only need to load extra args from stack.
+ * Must synch with [_emit_prepare_x86_call_args] *)
+let _emit_load_args_into_temps (ctx : context) (ordered_arg_temps : Temp.t list)
+  : context =
+  let load_extra_args ctx extra_arg_temps : context =
+    List.fold_left
+      (fun (ctx, offset_bytes) arg_temp ->
+         let mem_arg = Mem_arg (Rbp, offset_bytes) in
+         let instr = Load (mem_arg, Greg arg_temp) in
+         let ctx = _ctx_add_instr ctx instr in
+         (ctx, offset_bytes + _word_size))
+      (ctx, 2 * _word_size) extra_arg_temps
+    |> (fun (ctx, _) -> ctx)
+  in
+  let rec go ctx arg_temps (arg_prs : physical_reg list) : context =
+    match arg_temps, arg_prs with
+    | [], _ -> ctx
+    | _, [] -> load_extra_args ctx arg_temps
+    | _::rest_arg_temps, _::rest_arg_prs ->
+      go ctx rest_arg_temps rest_arg_prs
+  in
+  go ctx ordered_arg_temps ordered_argument_physical_regs
+;;
+
+let rec _emit_lir_expr (ctx : context) (e : Lir.expr) (dst_temp : Temp.t)
+  : context =
+  match e with
+  | Imm n -> 
+    let instr = Load (Imm_arg n, Greg dst_temp) in
+    _ctx_add_instr ctx instr
+
+  | Tmp temp -> (* XXX generate to [arg] would save 1 instr *)
+    let instr = Load (Reg_arg (Greg temp), Greg dst_temp) in
+    _ctx_add_instr ctx instr
+
+  | Op (op, lhs_e, rhs_e) ->
+    _emit_lir_op ctx op lhs_e rhs_e dst_temp
+
+  | Call (label_temp, es) ->
+    let ctx = _emit_prepare_x86_call_args ctx es in
+    let instr = Call_reg label_temp in
+    _ctx_add_instr ctx instr
+
+  | NativeCall (func_label, es) ->
+    let ctx = _emit_prepare_x86_call_args ctx es in
+    let instr = Call_lbl func_label in
+    _ctx_add_instr ctx instr
+
+  | Mem_alloc nbytes ->
+    let ctx = _emit_prepare_x86_call_args ctx [Imm nbytes] in
+    let instr = Call_lbl (Label.get_native "mem_alloc") in
+    _ctx_add_instr ctx instr
+
+(*       ......
+ * caller stack frame
+ * ------------------
+ * | 1st extra arg  |
+ * ------------------ <- RBP + 2 * word_size
+ * | return address |
+ * ------------------ <- RBP + 1 * word_size
+ * |    saved rbp   | 
+ * ------------------ <- RBP + 0 * word_size 
+ * callee stack frame
+ *      ......        *)
+and _emit_prepare_x86_call_args (init_ctx : context)
+    (init_arg_es : Lir.expr list)
+  : context =
+  (* last argument is pushed first, so 1st arg is closest to frame base *)
+  let _emit_push_onto_stack ctx arg_es =
+    List.fold_right
+      (fun arg_e ctx ->
+         let ctx, arg_v_temp = _ctx_gen_temp ctx in
+         let ctx = _emit_lir_expr ctx arg_e arg_v_temp in
+         _ctx_add_instr ctx (Push arg_v_temp))
+      arg_es ctx
+  in
+  let rec go ctx arg_es (ordered_arg_temps : Temp.t list)  =
+    match arg_es, ordered_arg_temps  with
+    | [], _ -> ctx
+    | _, [] -> _emit_push_onto_stack ctx arg_es
+    | arg_e::rest_arg_es, arg_temp::rest_arg_temps ->
+      let ctx = _emit_lir_expr ctx arg_e arg_temp in
+      go ctx rest_arg_es rest_arg_temps
+  in
+  let x86_arg_temps =
+    List.combine init_ctx.ordered_arg_temps ordered_argument_physical_regs
+    |> List.map (fun (temp, _) -> temp)
+  in
+  go init_ctx init_arg_es x86_arg_temps
+
+and _emit_lir_op (ctx : context)
+    (op : Lir.op) (lhs_e : Lir.expr) (rhs_e : Lir.expr) (dst_temp : Temp.t)
+  : context =
+  let ctx, rhs_temp = _ctx_gen_temp ctx in
+  let ctx = _emit_lir_expr ctx lhs_e dst_temp in
+  let ctx = _emit_lir_expr ctx rhs_e rhs_temp in
+  let binop =
+    match op with
+    | Add -> Add
+    | Sub -> Sub
+    | Mul -> Mul
+  in
+  let instr = Binop (binop, dst_temp, Reg_arg (Greg rhs_temp)) in
+  _ctx_add_instr ctx instr
+;;
+
+let _emit_comparison
+    (ctx : context) (lhs_e : Lir.expr) (rhs_e : Lir.expr)
+    : context =
+  let ctx, lhs_temp = _ctx_gen_temp ctx in
+  let ctx, rhs_temp = _ctx_gen_temp ctx in
+  let ctx = _emit_lir_expr ctx lhs_e lhs_temp in
+  let ctx = _emit_lir_expr ctx rhs_e rhs_temp in
+  let instr = Cmp (Reg_arg (Greg lhs_temp), rhs_temp) in
+  _ctx_add_instr ctx instr
+;;
+
+let _emit_lir_jump
+    (ctx : context) (lir_cond : Lir.cond) (target_label : Label.t)
+  : context =
+  match lir_cond with
+  | True -> 
+    _ctx_add_instr ctx (Jmp target_label)
+
+  | Less (lhs_e, rhs_e) ->
+    let ctx = _emit_comparison ctx lhs_e rhs_e in
+    let instr = JmpC (Lt, target_label) in
+    _ctx_add_instr ctx instr
+
+  | Equal (lhs_e, rhs_e) ->
+    let ctx = _emit_comparison ctx lhs_e rhs_e in
+    let instr = JmpC (Eq, target_label) in
+    _ctx_add_instr ctx instr
+;;
+
+let _emit_lir_set
+    (ctx : context) (lir_cond : Lir.cond) (target_temp : Temp.t)
+  : context =
+  match lir_cond with
+  | True -> 
+    let instr = Load (Imm_arg 1, Greg target_temp) in
+    _ctx_add_instr ctx instr
+
+  | Less (lhs_e, rhs_e) ->
+    let ctx = _emit_comparison ctx lhs_e rhs_e in
+    let instr = SetC (Lt, target_temp) in
+    _ctx_add_instr ctx instr
+
+  | Equal (lhs_e, rhs_e) ->
+    let ctx = _emit_comparison ctx lhs_e rhs_e in
+    let instr = SetC (Eq, target_temp) in
+    _ctx_add_instr ctx instr
+;;
+
+
+let _emit_lir_instr (ctx : context) (lir_instr : Lir.instr) : context =
+  (* TODO this could generate seriously inefficient code.
+   * To optimize, e.g., consider emit certain expr into arg instead of reg *)
+  match lir_instr with
+  | Label label ->
+    _ctx_add_instr ctx (Label label)
+
+  | Load (e, dst_temp) ->
+    _emit_lir_expr ctx e dst_temp
+
+  | LoadMem (src_addr_e, dst_temp) ->
+    let ctx = _emit_lir_expr ctx src_addr_e dst_temp in
+    let instr = Load (Mem_arg(Greg dst_temp, 0), Greg dst_temp) in
+    _ctx_add_instr ctx instr
+
+  | Store (e, dst_addr_e) ->
+    let ctx, e_temp = _ctx_gen_temp ctx in
+    let ctx, dst_addr_temp = _ctx_gen_temp ctx in
+    let ctx = _emit_lir_expr ctx e e_temp in
+    let ctx = _emit_lir_expr ctx dst_addr_e dst_addr_temp in
+    let instr = Store (Reg_arg(Greg e_temp), Greg dst_addr_temp, 0) in
+    _ctx_add_instr ctx instr
+
+  | Store_label (label, dst_addr_e) ->
+    let ctx, dst_addr_temp = _ctx_gen_temp ctx in
+    let ctx = _emit_lir_expr ctx dst_addr_e dst_addr_temp in
+    let instr = Store (Lbl_arg(label), Greg dst_addr_temp, 0) in
+    _ctx_add_instr ctx instr
+
+  | Jump (lir_cond, target_label) ->
+    _emit_lir_jump ctx lir_cond target_label
+
+  | Set (lir_cond, target_temp) ->
+    _emit_lir_set ctx lir_cond target_temp
+
+  | Ret e ->
+    let ctx = _emit_lir_expr ctx e ctx.rax_temp in
+    let epilogue_label = _ctx_get_epilogue_label ctx in
+    _ctx_add_instr ctx (Jmp epilogue_label)
+;;
+
+let _emit_lir_instrs (ctx : context) (lir_instrs : Lir.instr list) : context =
+  List.fold_left _emit_lir_instr ctx lir_instrs
+;;
+
+let _from_lir_func (lir_func : Lir.func) : temp_func =
+  let args = lir_func.ordered_args in
+  let ctx = _init_ctx lir_func.name args lir_func.temp_manager in
+  let ctx = _emit_load_args_into_temps ctx args in
+  let ctx = _emit_lir_instrs ctx lir_func.body in
+  let instrs = _ctx_get_instrs ctx in
+  let func_label = lir_func.name in
+  let func = { entry = func_label; instrs; args; rax = ctx.rax_temp; } in
+  func
+;;
+
+let _from_lir_main_func
+    (temp_manager : Temp.manager) (lir_instrs : Lir.instr list)
+  : temp_func =
+  (* TODO call "soml_init" here, or make this a function called by C runtime?
+   * TBD when implementing runtime. *)
+  let main_label = Label.get_native "main" in
+  let ctx = _init_ctx main_label [] temp_manager in
+  let ctx = _emit_lir_instrs ctx lir_instrs in
+  let instrs = _ctx_get_instrs ctx in
+  { entry = main_label; instrs; args = []; rax = ctx.rax_temp; } 
+;;
+
+let from_lir_prog (lir_prog : Lir.prog) : temp_prog =
+  let funcs = List.map _from_lir_func lir_prog.funcs in
+  let temp_main = _from_lir_main_func lir_prog.temp_manager lir_prog.entry in
+  { temp_funcs = funcs; temp_main }
+;;

--- a/lib/backend/x86.mli
+++ b/lib/backend/x86.mli
@@ -1,0 +1,89 @@
+open Pervasives
+
+(* physical registers of X86 ISA *)
+type physical_reg
+
+(* Some physical registers can't be used for register allocation *)
+type 'a reg =
+  | Rsp        (* not sure how allowing this in reg-alloc would affect things *)
+  | Rbp        (* we need rbp for spilling *)
+  | Greg of 'a (* general purpose registers *)
+
+(* argument to x86 instructions *)
+type 'a arg =
+  | Lbl_arg of Label.t      (* label, e.g., use function label as data *)
+  | Imm_arg of int          (* immediate, i.e., constants*)
+  | Reg_arg of 'a reg       (* load from [reg] *)
+  | Mem_arg of 'a reg * int (* load from address [reg + offset] *)
+
+(* for conditional operations *)
+type cond =
+  | Eq
+  | Lt
+
+(* for binary operations *)
+type binop =
+  | Add
+  | Sub
+  | Mul
+
+(* NOTE 
+ * 0. We parameterize over general-purpose registers, i.e., virtual or physical.
+ *    This differentiates x86 programs before and after register allocation.
+ * 1. I'm not being truthful to the X86 ISA here. I really took a subset of it
+ *    for simplicity, and since we don't need the other fancy instrs for now.
+ * 2. Many instructions don't support 2 memory accesses, I made that explicit.
+ *)
+type 'a instr = 
+  | Label of Label.t
+  | Load of 'a arg * 'a reg
+      (* Load (arg, reg) --> reg := arg *)
+  | Store of 'a arg * 'a reg * int
+      (* Store (arg, reg, offset) --> *[reg + offset] := arg *)
+  | Push of 'a
+  | Pop of 'a
+  | Binop of binop * 'a * 'a arg
+      (* Binop (op, gr, arg) --> gr := op gr arg *)
+  | Cmp of 'a arg * 'a
+  | Jmp of Label.t
+  | JmpC of cond * Label.t
+      (* Jump to label if [cond] is satisfied. *)
+  | Call_reg of 'a
+  | Call_lbl of Label.t
+  | SetC of cond * 'a
+      (* Sets content of ['a] to 1 if [cond] is satisfied, else 0 *)
+  | Ret
+      (* Return control flow to caller site *)
+
+
+(* A function in X86 with Temps and some annotation to help reg-alloc.
+ * NOTE without prologue/epilogue. *) 
+type temp_func = 
+  { entry  : Label.t
+  ; instrs : Temp.t instr list (* doesn't start with [entry] label *)
+  ; args   : Temp.t list
+  ; rax    : Temp.t
+  }
+
+(* A program in X86 before register allocation *)
+type temp_prog = 
+  { temp_funcs : temp_func list
+  ; temp_main  : temp_func
+  }
+
+
+(* A function unit in X86 after register allocation
+ * NOTE with prologue/epilogue; this is the final assembly code. *)
+type func =
+  { entry  : Label.t
+  ; instrs : physical_reg instr list (* doesn't start with [entry] label *)
+  }
+
+(* An entire program in X86 after register allocation *)
+type prog = 
+  { funcs : func list
+  ; main : func
+  }
+
+
+val from_lir_prog : Lir.prog -> temp_prog

--- a/lib/common/pretty.ml
+++ b/lib/common/pretty.ml
@@ -617,7 +617,7 @@ let _pp_lir_instrs (p : printer) (instrs : Lir.instr list) : unit =
 
 let _pp_lir_func (p : printer) (func : Lir.func) : unit =
   _print_strs p ["<"; Label.to_string func.name; ">:"]; _print_newline p;
-  let arg_strs = List.map Temp.to_string func.args in
+  let arg_strs = List.map Temp.to_string func.ordered_args in
   _print_strs p ["args: ["; String.join_with arg_strs ", "; "]"]; _print_newline p;
   _println_str p "body:";
   _inc_space p 2;

--- a/test/backend/label_test.ml
+++ b/test/backend/label_test.ml
@@ -15,17 +15,40 @@ let tests = OUnit2.(>:::) "label_test" [
         OUnit2.assert_equal false ((Label.to_string t3) = (Label.to_string t1));
       );
 
-    OUnit2.(>::) "test_create_native" (fun _ ->
+    OUnit2.(>::) "test_get_native" (fun _ ->
         let manager = Label.init_manager in
         let manager, t1 = Label.gen manager "s1" in
         let _, t2 = Label.gen_and_bind manager "s1" in
-        let foo_t = Label.create_native "foo" in
-        let bar_t = Label.create_native "bar" in
+        let foo_t = Label.get_native "foo" in
+        let bar_t = Label.get_native "bar" in
         OUnit2.assert_equal false ((Label.to_string t1) = (Label.to_string foo_t));
         OUnit2.assert_equal false ((Label.to_string t2) = (Label.to_string foo_t));
         OUnit2.assert_equal false ((Label.to_string t1) = (Label.to_string bar_t));
         OUnit2.assert_equal false ((Label.to_string t2) = (Label.to_string bar_t));
         OUnit2.assert_equal false ((Label.to_string foo_t) = (Label.to_string bar_t));
+      );
+
+    OUnit2.(>::) "test_to_epilogue" (fun _ ->
+        let manager = Label.init_manager in
+        let manager, t1 = Label.gen manager "s1" in
+        let _, t2 = Label.gen_and_bind manager "s1" in
+        let s1_native = Label.get_native "foo" in
+        let t1_epilogue = Label.to_epilogue t1 in
+        let t2_epilogue = Label.to_epilogue t2 in
+        OUnit2.assert_equal false 
+          ((Label.to_string t1) = (Label.to_string s1_native));
+        OUnit2.assert_equal false 
+          ((Label.to_string t2) = (Label.to_string s1_native));
+        OUnit2.assert_equal false 
+          ((Label.to_string t1) = (Label.to_string t1_epilogue));
+        OUnit2.assert_equal false 
+          ((Label.to_string t2) = (Label.to_string t2_epilogue));
+        OUnit2.assert_equal false 
+          ((Label.to_string s1_native) = (Label.to_string t1_epilogue));
+        OUnit2.assert_equal false 
+          ((Label.to_string s1_native) = (Label.to_string t2_epilogue));
+        OUnit2.assert_equal false 
+          ((Label.to_string t1_epilogue) = (Label.to_string t2_epilogue));
       );
 
     (* test with [get] together *)


### PR DESCRIPTION
As title suggests, this is not the entire X86 backend yet.

I spent a few days implementing the X86 backend and register allocation in parallel, so I could tweak the design and make sure I was in the right direction.

Note that my data representation is a strict subset of the real X86, but
- it's expressive enough for producing a working program
- it helped me _make illegal state unrepresentable_, e.g.,
  - parameterized instruction strictly separates code before and after register allocation
  -`Load` and `Store` instead of `Mov` prevents multiple memory accesses in 1 instruction