### PR TITLE
Liveness analysis

### DIFF
--- a/lib/backend/graph.ml
+++ b/lib/backend/graph.ml
@@ -1,0 +1,128 @@
+open Pervasives
+
+type node = int
+
+let _empty_node_set = Set.empty Int.compare
+;;
+
+
+type 'a node_info =
+  { out_nbs : node Set.t
+  ; in_nbs  : node Set.t
+  ; annot   : 'a
+  }
+
+type 'a t =
+  { node_infos        : (node, 'a node_info) Map.t
+  ; next_node         : node
+  }
+
+
+let empty_graph () =
+  { node_infos    = Map.empty Int.compare
+  ; next_node     = 0
+  }
+;;
+
+let _get_node_info (t : 'a t) (n : node) (func : string) : 'a node_info =
+  match Map.get n t.node_infos with
+  | None ->
+    failwith 
+      (String.join_with ["[Graph."; func; "] node not bound in graph"] "")
+  | Some info -> info
+;;
+
+let _check_node_exists t (n : node) (func : string) : unit =
+  let _ = _get_node_info t n func in
+  ()
+;;
+
+let _set_node_info (t : 'a t) (n : node) (info : 'a node_info) : 'a t =
+  let node_infos = Map.add n info t.node_infos in
+  { t with node_infos }
+;;
+
+let create_node t annot =
+  let node = t.next_node in
+  let info = { out_nbs = _empty_node_set
+             ; in_nbs = _empty_node_set
+             ; annot } in
+  let t = _set_node_info t node info in
+  let t = { t with next_node = node + 1 } in
+  (t, node)
+;;
+
+let remove_node t node =
+  (* NOTE [_get_node_info] disallows batch update, unless we add another
+   * indirection, but KISS for now. *)
+  let _remove_node_from_out_nbs_of t to_remove nodes : 'a t =
+    Set.fold
+      (fun t node ->
+         let node_info = _get_node_info t node "remove_node" in
+         let node_info = { node_info with
+                           out_nbs = Set.remove to_remove node_info.out_nbs } in
+         { t with node_infos = Map.add node node_info t.node_infos })
+      t nodes
+  in
+  let _remove_node_from_in_nbs_of t to_remove nodes : 'a t =
+    Set.fold
+      (fun t node ->
+         let node_info = _get_node_info t node "remove_node" in
+         let node_info = { node_info with
+                           in_nbs = Set.remove to_remove node_info.in_nbs } in
+         { t with node_infos = Map.add node node_info t.node_infos })
+      t nodes
+  in
+  (* must severe connections first then remove node, to maintain invariants *)
+  let info = _get_node_info t node "remove_node" in
+  let t = _remove_node_from_out_nbs_of t node info.in_nbs in
+  let t = _remove_node_from_in_nbs_of t node info.out_nbs in
+  { t with node_infos = Map.remove node t.node_infos }
+;;
+
+let get_annot t node =
+  let info = _get_node_info t node "get_annot" in
+  info.annot
+;;
+
+let set_annot t node annot =
+  let info = _get_node_info t node "set_annot" in
+  let new_info = { info with annot } in
+  _set_node_info t node new_info
+;;
+
+let add_edge t src dst =
+  let src_info = _get_node_info t src "add_edge" in
+  let dst_info = _get_node_info t dst "add_edge" in
+  let src_out_nbs = Set.add dst src_info.out_nbs in
+  let dst_in_nbs  = Set.add src dst_info.in_nbs in
+  let new_src_info = { src_info with out_nbs = src_out_nbs } in
+  let new_dst_info = { dst_info with in_nbs = dst_in_nbs } in
+  let t = _set_node_info t src new_src_info in
+  _set_node_info t dst new_dst_info
+;;
+
+let get_out_neighbors t node =
+  let info = _get_node_info t node "add_edge" in
+  info.out_nbs
+;;
+
+let get_in_neighbors t node =
+  let info = _get_node_info t node "add_edge" in
+  info.in_nbs
+;;
+
+let map f t =
+  let node_infos =
+    Map.map
+      (fun info -> 
+         let new_annot = f info.annot in
+         { info with annot = new_annot })
+        t.node_infos
+  in
+  { t with node_infos }
+;;
+
+let get_all_nodes t =
+  Map.get_key_set t.node_infos
+;;

--- a/lib/backend/graph.mli
+++ b/lib/backend/graph.mli
@@ -1,0 +1,32 @@
+
+(** A directed graph parameterized over attribute associated with each node *)
+type 'a t
+
+(** A [node] is an opaque handle to internal node in some ['a t].
+    NOTE Error if any input node is removed or not created within input [t] *)
+type node
+
+(** t is immutable, but OCaml's type system disallows generalization here... *)
+val empty_graph : unit -> 'a t
+
+(** [create_node t annot] create a unique node in [t] annotated with [annot]
+    The annotation type can change later, as long as the node is still in [t] *)
+val create_node : 'a t -> 'a -> ('a t * node)
+
+(** [remove_node t node] returns a new [t] with [node] completely removed, i.e.,
+    as itself or neighbors of other nodes. *)
+val remove_node : 'a t -> node -> 'a t
+
+(* Some query functions *)
+val get_annot : 'a t -> node -> 'a
+val set_annot : 'a t -> node -> 'a -> 'a t
+val add_edge  : 'a t -> node -> node -> 'a t
+val get_out_neighbors : 'a t -> node -> node Set.t
+val get_in_neighbors  : 'a t -> node -> node Set.t
+
+(** in no particular order *)
+val get_all_nodes     : 'a t -> node Set.t
+
+(** All nodes created in [t] and are still present can still be used with output
+    [t], despite potential change to the annotations *)
+val map : ('a -> 'b) -> 'a t -> 'b t

--- a/lib/backend/liveness_analysis.ml
+++ b/lib/backend/liveness_analysis.ml
@@ -1,0 +1,196 @@
+open Pervasives
+
+(* # Notes
+ *
+ * - ($...) is used for footnotes.
+ *
+ * ## Equation
+ *
+ * (1). live_out[B] := Union (live-in[S] for sucessor S of B)
+ * (2). live_in[B]  := Gen[B] U (live_out[B] - Kill[B])
+ * (3). Gen[B]      := temps in B that are read before written to
+ * (4). Kill[B]     := temps in B that are written to
+ *
+ *
+ * ## Intuition
+ *
+ * (1). If a temp is alive in _any_ path from end of B, it's alive,
+ *      we must be conservative here, thus (1).
+ *
+ * (2). What temps are alive before entry of B? Either of the following:
+ *
+ *      - Temps whose definitions before entry are used in B, i.e.,
+ *        before a new assignment/definition, if any, thus (2) and (3)
+ *
+ *      - (3) doesn't cover everything, because it only looks within B,
+ *        what about after B? That's live_out[B]! But remember any
+ *        definition in B kills the defined temp at live_in, thus (2) and (4).
+ *
+ * ## Implementation
+ *
+ * ### Static Gen and Kill set calculation
+ *
+ * Traverse [B] forward (reads happen before writes) ($)
+ * - For Gen[B], we add reads that are not in Kill[B] (read before written to)
+ * - Kill[B] is easy to accumulate, just add written temps.
+ *
+ *
+ * ### Solving equation (1) and (2)
+ *
+ * Keep applying equation (1) and (2) until all live_in[B] and live_out[B]
+ * stop changing. NOTE that
+ *
+ * - Order matters, we update live_out[B] first because it depends on info
+ *   from other blocks, whereas live_in[B] only depends on live_out[B]
+ *   (basically the propagation is backward at block level).
+ *
+ * - We maintain (2) as an invariant for each blokc on a worklist.
+ *
+ *    - During initialization, set live_out[B] to empty set ($$) and apply (2)
+ *      once to establish (2) as an invariant. ($$$) Put all blocks onto the
+ *      worklist.
+ *
+ *    - Take 1 block from worklist and apply (1) _then_ (2) to it:
+ *
+ *      - if live_in[B] didn't change, we know predecessors of B won't be
+ *        affected by this change, nothing happens.
+ *
+ *      - if live_in[B] changed, the live_out sets of predecessors of B
+ *        _might_ change, so we re-compute all of them. (put onto a worklist)
+ *
+ *    - TERMINATION: live_out[B] monotonically increases for any B if we start
+ *      with empty set, since (2) is maintained as an invariant, and the set of
+ *      temps is finite, (1) must converge for all blocks at some point.
+ *
+ *
+ * ### Annotating individual instructions
+ *
+ * Use live_out[B] to propagate liveness info to each instr _backwards_.
+ * (writes happen before reads)
+ *
+ * - to update live_out for next (or previous technically) instr
+ *   - Remove written temps from live_out (use of these definitions end here)
+ *   - Add read temps into live_out       (use of some previous definitionss)
+ *
+ * - If we use live_in[B] and propagate forwards, we can't immediately find
+ *   out whether a newly defined temp will be used in the rest of B.
+ * 
+ *
+ * ## Footnotes
+ *
+ * ($) The order of reads and writes matters, consider [T1 = T1 + 1].
+ *
+ * ($$)
+ *      entry:          
+ *        T1 = T2 + 1
+ *        T2 = 42
+ *      loop:           # technically T2 is dead after this point
+ *        ...           # anything that doesn't contain T2
+ *        jmp loop
+ *
+ *      If we initialize live-out with [T2], loop won't kill or gen T2
+ *      Eventually we get
+ *      - live-in[loop]   = [..., T2]
+ *      - live-out[loop]  = [..., T2]
+ *      - live-in[entry]  = [...]
+ *      - live-out[entry] = [..., T2]
+ *
+ *      The extra T2 in live-in[loop] is problematic, especially for register
+ *      allocation.
+ *
+ * ($$$) Technically we could do initialize live_in to empty set too, since (2)
+ *       will be established after first iteration. But I think enforcing (2) at
+ *       beginning is nicer to reason about, bit faster, and no more complex.
+ *)
+
+type annot =
+  { live_out : Temp.t Set.t
+  }
+
+type block_annot =
+  { live_out : Temp.t Set.t
+  ; live_in  : Temp.t Set.t
+  ; gen      : Temp.t Set.t
+  ; kill     : Temp.t Set.t
+  }
+
+let _init_block_annot (block : Vasm.t list) : block_annot =
+  let empty_set = Set.empty Temp.compare in
+  let gen, kill =
+    List.fold_left 
+      (fun (gen, kill) (instr : Vasm.t) ->
+         let reads, writes = (Vasm.get_reads instr, Vasm.get_writes instr) in
+         let read_before_written = Set.diff reads kill in
+         let gen = Set.union read_before_written gen in
+         let kill = Set.union writes kill in
+         (gen, kill))
+      (empty_set, empty_set) block
+  in
+  let live_in, live_out = gen, empty_set in (* optimized (2) *)
+  { gen; kill; live_in; live_out }
+;;
+
+(* update live_out and then live_in *)
+let compute_new_block_annot cfg (node : Graph.node) : block_annot =
+  let _, block_annot = Graph.get_annot cfg node in
+  let gen, kill = block_annot.gen, block_annot.kill in
+  let new_live_out =
+    Set.fold
+      (fun new_live_out succ_node -> 
+         let _, succ_block_annot = Graph.get_annot cfg succ_node in
+         Set.union new_live_out succ_block_annot.live_in)
+      block_annot.live_out
+      (Graph.get_out_neighbors cfg node)
+      (* don't need to start from empty because live_out never shrinks *)
+  in
+  let new_live_in = Set.union gen (Set.diff new_live_out kill) in
+  { block_annot with live_in = new_live_in; live_out = new_live_out }
+;;
+
+let _compute_live_in_out_until_stablize
+    (init_cfg : (Vasm.t list * block_annot) Graph.t)
+  : (Vasm.t list * block_annot) Graph.t =
+
+  let rec go cfg (might_change : Graph.node Set.t)
+  : (Vasm.t list * block_annot) Graph.t =
+    match Set.get_one might_change with
+    | None -> cfg 
+    | Some node ->
+      let might_change = Set.remove node might_change in
+      let block, block_annot = Graph.get_annot cfg node in
+      let new_block_annot = compute_new_block_annot cfg node in
+      let new_node_annot = (block, new_block_annot) in
+      let cfg = Graph.set_annot cfg node new_node_annot in
+      (* live_out never shrinks (thus live_in too), so checking size suffices *)
+      if (Set.size block_annot.live_in) = (Set.size new_block_annot.live_in)
+      then go cfg might_change
+      else 
+        let predecessors = Graph.get_in_neighbors cfg node in
+        go cfg (Set.union predecessors might_change)
+  in
+  go init_cfg (Graph.get_all_nodes init_cfg)
+;;
+
+let _annot_instructions_in_block
+    ((block : Vasm.t list), (block_annot : block_annot))
+  : (Vasm.t * annot) list =
+  List.fold_right (* backward analysis, instruction order also preserved *)
+    (fun (instr : Vasm.t) (annot_instrs, live_out) ->
+       let annot = { live_out } in
+       let annot_instrs = (instr, annot)::annot_instrs in
+       let reads, writes = (Vasm.get_reads instr, Vasm.get_writes instr) in
+       let live_out = Set.diff live_out writes in (* update for next iteration *)
+       let live_out = Set.union live_out reads in
+       (annot_instrs, live_out))
+    block ([], block_annot.live_out)
+  |> (fun (annot_instrs, _) -> annot_instrs)
+;;
+
+let analyze_vasm (vasms : Vasm.t list) : (Vasm.t * annot) list =
+  let cfg, ordered_nodes = Vasm.build_cfg vasms in
+  let cfg = Graph.map (fun block -> (block, _init_block_annot block)) cfg in
+  let cfg = _compute_live_in_out_until_stablize cfg in
+  let cfg = Graph.map _annot_instructions_in_block cfg in
+  let ordered_blocks = List.map (Graph.get_annot cfg) ordered_nodes in
+  List.flatten ordered_blocks
+;;

--- a/lib/backend/liveness_analysis.mli
+++ b/lib/backend/liveness_analysis.mli
@@ -1,0 +1,12 @@
+open Pervasives
+
+(* An [annot] is an annotation for a single [Vasm.t] *)
+type annot =
+  { live_out : Temp.t Set.t (* Temps whose definition at a [Vasm.t] might be
+                               used later *)
+  }
+
+
+(** [analyze_vasm vasms] analyzes [vasms] in order, and annotate each [Vasm.t]
+    with liveness information *)
+val analyze_vasm : Vasm.t list -> (Vasm.t * annot) list

--- a/lib/backend/temp.ml
+++ b/lib/backend/temp.ml
@@ -41,3 +41,6 @@ let get manager s =
 let to_string t =
   String.append "T" (Int.to_string t)
 ;;
+
+let compare = Int.compare
+;;

--- a/lib/backend/temp.mli
+++ b/lib/backend/temp.mli
@@ -24,3 +24,7 @@ val gen_and_bind : manager -> string -> (manager * t)
 
 (** [to_string t] returns a string representation of [t] *)
 val to_string : t -> string
+
+(** Forms a well-define ordering of [t], where negative result means less than,
+    zero means equal, and positive means greater than *)
+val compare : t -> t -> int

--- a/lib/backend/vasm.ml
+++ b/lib/backend/vasm.ml
@@ -1,0 +1,212 @@
+open Pervasives
+
+type jump_kind =
+  | Unconditional
+  | Conditional
+
+type jump =
+  { target : Label.t
+  ; kind   : jump_kind
+  }
+
+type instr =
+  { reads  : Temp.t Set.t 
+  ; writes : Temp.t Set.t 
+  ; jump   : jump option
+  }
+
+type t =
+  | Instr of instr
+  | Label of Label.t
+  | Call  of Temp.t Set.t
+
+
+let get_reads t : Temp.t Set.t =
+  match t with
+  | Label _     -> Set.empty Temp.compare
+  | Call  reads -> reads
+  | Instr instr -> instr.reads
+;;
+
+let get_writes t : Temp.t Set.t =
+  match t with
+  | Label _ | Call _  -> Set.empty Temp.compare
+  | Instr instr -> instr.writes
+;;
+
+type block_info =
+  { instrs : t list
+  ; node   : Graph.node
+  }
+
+(* context to help build a cfg *)
+type context =
+  { next_block_id        : int
+  ; curr_block_id        : int
+  ; rev_curr_block_vasms : t list
+  ; label_to_block_id    : (string, int) Map.t
+  ; id_to_block_info     : (int, block_info) Map.t
+  ; block_id_graph       : int Graph.t
+  ; rev_finished_nodes   : Graph.node list (* in reverse order of finishing *)
+  }
+
+(* use and return [ctx.next_block_id]. NOTE won't change [ctx.curr_block_id] *)
+let _ctx_allocate_new_block (ctx : context) : (context * int) =
+  let new_block_id = ctx.next_block_id in
+  let new_graph, node = Graph.create_node ctx.block_id_graph new_block_id in
+  let block_info = { instrs = []; node } in
+  let id_to_block_info = Map.add new_block_id block_info ctx.id_to_block_info in
+  let ctx = { ctx with id_to_block_info;
+                       next_block_id = new_block_id + 1;
+                       block_id_graph = new_graph } in
+  (ctx, new_block_id)
+;;
+
+let _ctx_get_block_info (ctx : context) (id : int) : block_info =
+  match Map.get id ctx.id_to_block_info with
+  | None -> failwith "[Vasm._ctx_get_block_info] Unbound id"
+  | Some block_info -> block_info
+;;
+
+let _ctx_get_node (ctx : context) (id : int) : Graph.node =
+  (_ctx_get_block_info ctx id).node
+;;
+
+(* Return node of starting block too. NO SIDE EFFECT *)
+let _ctx_init : context =
+  let ctx = { next_block_id        = 0
+            ; curr_block_id        = -1 (* temporary garbage *)
+            ; rev_curr_block_vasms = []
+            ; label_to_block_id    = Map.empty String.compare
+            ; id_to_block_info     = Map.empty Int.compare
+            ; block_id_graph       = Graph.empty_graph () 
+            ; rev_finished_nodes   = [] }
+  in
+  let ctx, start_id = _ctx_allocate_new_block ctx in
+  { ctx with curr_block_id = start_id }
+;;
+
+let _ctx_add_block_info (ctx : context) (id : int) (info : block_info)
+  : context =
+  let id_to_block_info = Map.add id info ctx.id_to_block_info in
+  { ctx with id_to_block_info }
+;;
+
+let _ctx_get_or_gen_label_id (ctx : context) (label : Label.t)
+  : (context * int) =
+  let label_str = Label.to_string label in
+  match Map.get label_str ctx.label_to_block_id with
+  | Some block_id -> (ctx, block_id)
+  | None ->
+    let ctx, block_id = _ctx_allocate_new_block ctx in
+    let label_to_block_id = Map.add label_str block_id ctx.label_to_block_id in
+    let ctx = { ctx with label_to_block_id } in
+    (ctx, block_id)
+;;
+
+let _ctx_get_block_instrs (ctx : context) (id : int) : t list =
+  (_ctx_get_block_info ctx id).instrs
+;;
+
+let _ctx_add_edge_btw_blocks (ctx : context) (src_id : int) (dst_id : int)
+  : context =
+  let src_node = _ctx_get_node ctx src_id in
+  let dst_node = _ctx_get_node ctx dst_id in
+  let block_id_graph = Graph.add_edge ctx.block_id_graph src_node dst_node in
+  { ctx with block_id_graph }
+;;
+
+let _ctx_add_instr (ctx : context) t : context =
+  let rev_curr_block_vasms = t::ctx.rev_curr_block_vasms in
+  { ctx with rev_curr_block_vasms }
+;;
+
+(* won't update [next/curr_block_id] or [rev_curr_block_vasms] *)
+let _ctx_finish_curr_block (ctx : context) : context =
+  let block_instrs = List.rev ctx.rev_curr_block_vasms in
+  let block_id = ctx.curr_block_id in
+  let block_info = _ctx_get_block_info ctx block_id in
+  let block_info = { block_info with instrs = block_instrs } in
+  let id_to_block_info = Map.add block_id block_info ctx.id_to_block_info in
+  let rev_finished_nodes = block_info.node::ctx.rev_finished_nodes in
+  { ctx with id_to_block_info; rev_finished_nodes }
+;;
+
+let _ctx_start_block_with_label (ctx : context) (label : Label.t) : context =
+  let ctx, new_block_id = _ctx_get_or_gen_label_id ctx label in
+  { ctx with curr_block_id = new_block_id;
+             rev_curr_block_vasms = [] }
+;;
+
+(* NOTE source of intermediate empty block. *)
+let _ctx_start_block (ctx : context) : context =
+  let ctx, new_id = _ctx_allocate_new_block ctx in
+  { ctx with curr_block_id = new_id 
+           ; rev_curr_block_vasms = [] }
+;;
+
+let _ctx_handle_label (ctx : context) (label : Label.t) : context =
+  let old_block_id = ctx.curr_block_id in
+  let ctx = _ctx_finish_curr_block ctx in
+  let ctx = _ctx_start_block_with_label ctx label in
+  let new_block_id = ctx.curr_block_id in
+  let ctx = _ctx_add_edge_btw_blocks ctx old_block_id new_block_id in
+  _ctx_add_instr ctx (Label label)
+;;
+
+(* add edges and create id for label if needed *)
+let _ctx_handle_instr (ctx : context) (instr : instr) : context =
+  let ctx = _ctx_add_instr ctx (Instr instr) in
+  match instr.jump with
+  | None -> ctx
+  | Some jump ->
+    let ctx, target_id = _ctx_get_or_gen_label_id ctx jump.target in
+    let ctx = _ctx_add_edge_btw_blocks ctx ctx.curr_block_id target_id in
+    let ctx = _ctx_finish_curr_block ctx in
+    let old_block_id = ctx.curr_block_id in
+    let ctx = _ctx_start_block ctx in
+    match jump.kind with
+    | Unconditional -> ctx
+    | Conditional ->
+      _ctx_add_edge_btw_blocks ctx old_block_id ctx.curr_block_id
+;;
+
+(* update [ctx] for wiring between nodes, starting new node, or adding [t] *)
+let _ctx_handle_one_vasm (ctx : context) t : context =
+  match t with
+  | Label label -> _ctx_handle_label ctx label
+  | Instr instr -> _ctx_handle_instr ctx instr
+  | Call _      -> _ctx_add_instr ctx t (* no inter-procedural analysis *)
+;;
+
+let rec _ctx_handle_vasms (ctx : context) (ts : t list) : context =
+  match ts with
+  | [] -> _ctx_finish_curr_block ctx
+  | t::ts ->
+    let ctx = _ctx_handle_one_vasm ctx t in
+    _ctx_handle_vasms ctx ts
+;;
+
+(* not operating o [ctx] because I don't want to break its invariants *)
+let _keep_only_finished_nodes_in_cfg
+    (ctx : context) (cfg: 'a Graph.t) : 'a Graph.t =
+  let all_node_set = Graph.get_all_nodes cfg in
+  let unfinished_node_set =
+    List.fold_right Set.remove ctx.rev_finished_nodes all_node_set
+  in
+  Set.fold
+    (fun cfg node ->
+       if Set.mem node unfinished_node_set
+       then Graph.remove_node cfg node
+       else cfg)
+    cfg all_node_set
+;;
+
+let build_cfg vasms =
+  let ctx = _ctx_init in
+  let ctx = _ctx_handle_vasms ctx vasms in
+  let cfg = _keep_only_finished_nodes_in_cfg ctx ctx.block_id_graph in
+  let cfg = Graph.map (_ctx_get_block_instrs ctx) cfg in
+  let finished_nodes = List.rev ctx.rev_finished_nodes in
+  (cfg, finished_nodes)
+;;

--- a/lib/backend/vasm.mli
+++ b/lib/backend/vasm.mli
@@ -1,0 +1,48 @@
+open Pervasives
+
+type jump_kind =
+  | Unconditional
+  | Conditional
+
+type jump =
+  { target : Label.t
+  ; kind   : jump_kind
+  }
+
+(* NOTE ASSUME read happen before write *)
+type instr =
+  { reads  : Temp.t Set.t (* temps written to in this instr *)
+  ; writes : Temp.t Set.t (* temps read from in this instr *)
+  ; jump   : jump option  (* whether this instruction jumps to some label *)
+  }
+
+type t =
+  | Instr of instr
+  | Label of Label.t
+  | Call  of Temp.t Set.t (* reads *)
+
+
+(* Some query functions over [t] *)
+val get_reads  : t -> Temp.t Set.t
+val get_writes : t -> Temp.t Set.t
+
+
+(** Returns 
+    - a primitive control flow graph where each node is annotated with all
+      the instructions in it, in order.
+
+    - a list of nodes based on order of input instructions; in other words,
+      one can use [Graph.get_annot] to linearize the CFG to its original
+      instruction list.
+  
+    A block starts at either
+      - beginning
+      - a label
+      - after a conditional or direct jump to some label
+   
+    NOTE
+    1. External jumps (e.g., for tail calls) will be considered end of block,
+       because we don't do inter-procedural analysis.
+    2. We might end up with some empty intermediate blocks in the output graph;
+       we could eliminate them by searching and merging, but KISS for now. *)
+val build_cfg  : t list -> (t list Graph.t * Graph.node list)

--- a/lib/common/pretty.ml
+++ b/lib/common/pretty.ml
@@ -642,3 +642,38 @@ let pp_lir_prog prog =
   _pp_lir_prog p prog;
   p.buffer
 ;;
+
+
+let _pp_vasm_jump (p : printer) (jump : Vasm.jump) : unit =
+  let kind_str =
+    match jump.kind with
+    | Conditional -> "conditional"
+    | Unconditional -> "unconditional"
+  in
+  _print_strs p [kind_str; " jump to "; Label.to_string jump.target];
+;;
+
+let _pp_vasm_instr (p : printer) (instr : Vasm.instr) : unit =
+  _print_strs p
+    ["instr, reads = "; Set.to_string Temp.to_string instr.reads;
+     ", writes = "; Set.to_string Temp.to_string instr.writes;];
+  match instr.jump with
+  | None -> ()
+  | Some jump ->
+    _print_str p ", jump = ";
+    _pp_vasm_jump p jump
+;;
+
+let _pp_vasm (p : printer) (vasm : Vasm.t) : unit =
+  match vasm with
+  | Label label -> _print_str p (Label.to_string label)
+  | Call  reads -> 
+    _print_strs p ["call("; Set.to_string Temp.to_string reads; ")"]
+  | Instr instr -> _pp_vasm_instr p instr
+;;
+
+let pp_vasm vasm =
+  let p = _create_printer () true in
+  _pp_vasm p vasm;
+  p.buffer
+;;

--- a/lib/common/pretty.mli
+++ b/lib/common/pretty.mli
@@ -19,3 +19,4 @@ val pp_typer_error      : Errors.typer_error -> string
 (* Backend stuff *)
 val pp_cir : Cir.prog -> string
 val pp_lir_prog : Lir.prog -> string
+val pp_vasm : Vasm.t -> string

--- a/lib/stdlib/map.ml
+++ b/lib/stdlib/map.ml
@@ -84,3 +84,10 @@ let to_string f g t =
   let inner = String.join_with pairs "; " in
   String.append "{" (String.append inner "}")
 ;;
+
+let get_key_set t =
+  List.fold_right 
+    (fun (key, _) key_set -> Set.add key key_set)
+    (_unique_pairs t)
+    (Set.empty t.cmp)
+;;

--- a/lib/stdlib/map.mli
+++ b/lib/stdlib/map.mli
@@ -48,3 +48,6 @@ val foldi : ('k -> 'v -> 'b -> 'b) -> ('k, 'v) t -> 'b -> 'b
 (** [to_string f g t] returns a string representation of the [t], using [f] to
     format individual keys, and [g] for elements. *)
 val to_string : ('k -> string) -> ('v -> string) -> ('k, 'v) t -> string
+
+(** [get_key_set t] returns all the keys present in [t] as a set *)
+val get_key_set : ('k, 'v) t -> 'k Set.t

--- a/lib/stdlib/pervasives.ml
+++ b/lib/stdlib/pervasives.ml
@@ -10,3 +10,7 @@ type 'a option =
 type ('a, 'e) result =
   | Ok of 'a
   | Error of 'e
+
+let not b =
+  if b then false else true
+;;

--- a/lib/stdlib/pervasives.mli
+++ b/lib/stdlib/pervasives.mli
@@ -20,3 +20,5 @@ type 'a option =
 type ('a, 'e) result =
   | Ok of 'a
   | Error of 'e
+
+val not : bool -> bool

--- a/lib/stdlib/set.ml
+++ b/lib/stdlib/set.ml
@@ -34,6 +34,12 @@ let remove e t =
   { t with rep = List.filter (fun x -> not (_equal_by_cmp t.cmp e x)) t.rep }
 ;;
 
+let get_one t =
+  match t.rep with
+  | [] -> None
+  | e::_ -> Some e
+;;
+
 let mem e t =
   match List.find_opt (_equal_by_cmp t.cmp e) t.rep with
   | None   -> false
@@ -46,6 +52,19 @@ let size t =
 
 let map f t =
   { t with rep = List.map f t.rep }
+;;
+
+let filter p t =
+  { t with rep = List.filter p t.rep }
+;;
+
+let find p t =
+  List.find_opt p t.rep
+;;
+
+let fold f acc t =
+  let unique_elems = _unique_elems t in
+  List.fold_left f acc unique_elems
 ;;
 
 let union t1 t2 =
@@ -79,4 +98,8 @@ let to_string f t =
   let es = List.map f (_unique_elems t) in
   let inner = String.join_with es "; " in
   String.append "{" (String.append inner "}")
+;;
+
+let get_compare_func t =
+  t.cmp
 ;;

--- a/lib/stdlib/set.mli
+++ b/lib/stdlib/set.mli
@@ -24,11 +24,26 @@ val add : 'e -> 'e t -> 'e t
 (** [remove e t] returns a set where [e] is absent *)
 val remove : 'e -> 'e t -> 'e t
 
+(** [get_one t] tries to get some element from [t].
+    Return [None] if [t] is empty. *)
+val get_one : 'e t -> 'e option
+
 (** [mem e t] returns true iff [e] is present in [t] *)
 val mem : 'e -> 'e t -> bool
 
 (** [map f t] returns a new map where each value [v] in [t] becomes [f v] *)
 val map : ('e -> 'e) -> 'e t -> 'e t
+
+(** [filter p t] returns a subset of [t] whose elements satisfy [p]. *)
+val filter : ('e -> bool) -> 'e t -> 'e t
+
+(** [find p t] returns some element in [t] that satisfies [p],
+    or None if such element doesn't exist in [t]. *)
+val find : ('e -> bool) -> 'e t -> 'e option
+
+(** [fold f a t] is (f (... (f (f a e1) e2)  ...) en),
+    where e1 ... eN are all the elements in [t] *)
+val fold : ('a -> 'e -> 'a) -> 'a -> 'e t -> 'a
 
 (** [union t1 t2] returns a new set that contains all the elements in either 
     [t1] or [t2]. *)
@@ -53,3 +68,7 @@ val to_list : 'e t -> 'e list
 (** [to_string f t] returns a string representation of the [t], using [f] to
     format individual elements *)
 val to_string : ('e -> string) -> 'e t -> string
+
+(** [get_compare_func t] returns the compare function for elements of [t],
+    passed in during [t]'s construction. *)
+val get_compare_func : 'e t -> ('e -> 'e -> int)

--- a/test/backend/backend_aux.ml
+++ b/test/backend/backend_aux.ml
@@ -1,0 +1,40 @@
+open Pervasives
+
+let temps_to_set (temps : Temp.t list) : Temp.t Set.t =
+  List.fold_right Set.add temps (Set.empty Temp.compare)
+;;
+
+let mk_instr
+    (reads : Temp.t list) (writes : Temp.t list) (jump : Vasm.jump option)
+  : Vasm.t =
+  Vasm.Instr
+    { reads = temps_to_set reads;
+      writes = temps_to_set writes;
+      jump }
+;;
+
+let mk_instr_no_jump (reads : Temp.t list) (writes : Temp.t list) : Vasm.t =
+  mk_instr reads writes None
+;;
+
+let mk_instr_dir_jump
+    (reads : Temp.t list) (writes : Temp.t list) (target : Label.t) : Vasm.t =
+  let jump = { Vasm.target; kind = Unconditional } in
+  mk_instr reads writes (Some jump)
+;;
+
+let mk_instr_cond_jump
+    (reads : Temp.t list) (writes : Temp.t list) (target : Label.t) : Vasm.t =
+  let jump = { Vasm.target; kind = Conditional } in
+  mk_instr reads writes (Some jump)
+;;
+
+let mk_call (reads : Temp.t list) : Vasm.t =
+  Vasm.Call (temps_to_set reads)
+;;
+
+let mk_label (label : Label.t) : Vasm.t =
+  Vasm.Label label
+;;
+
+

--- a/test/backend/backend_aux.mli
+++ b/test/backend/backend_aux.mli
@@ -1,0 +1,11 @@
+open Pervasives
+
+val temps_to_set : Temp.t list -> Temp.t Set.t
+
+(* convenience constructors for vasm instructions *)
+val mk_instr : Temp.t list -> Temp.t list -> Vasm.jump option -> Vasm.t
+val mk_instr_no_jump : Temp.t list -> Temp.t list -> Vasm.t
+val mk_instr_dir_jump : Temp.t list -> Temp.t list -> Label.t -> Vasm.t
+val mk_instr_cond_jump : Temp.t list -> Temp.t list -> Label.t -> Vasm.t
+val mk_call : Temp.t list -> Vasm.t
+val mk_label : Label.t -> Vasm.t

--- a/test/backend/graph_test.ml
+++ b/test/backend/graph_test.ml
@@ -1,0 +1,139 @@
+open Pervasives
+
+let _add_edges (graph : 'a Graph.t) (edges : (Graph.node * Graph.node) list)
+  : 'a Graph.t =
+  List.fold_left
+    (fun graph (src_node, dst_node) ->
+       Graph.add_edge graph src_node dst_node)
+    graph edges
+;;
+
+let _check_edges
+    (graph : 'a Graph.t) (edges : (Graph.node * Graph.node list) list) : unit =
+  List.iter (* check out_neighbor of each src_node *)
+    (fun (src_node, dst_nodes) ->
+       Test_aux.check_set dst_nodes (Graph.get_out_neighbors graph src_node);
+       List.iter (* check each in_neighbor of dst_node *)
+         (fun dst_node ->
+            OUnit2.assert_bool
+              "edge should create in_neighbors too"
+              (Set.mem src_node (Graph.get_in_neighbors graph dst_node)))
+         dst_nodes)
+    edges
+;;
+
+(* NOTE general structural comparison is used to check equality of annots *)
+let _check_nodes_and_annots
+    (graph : 'a Graph.t) (expected_annots : (Graph.node * 'a) list) : unit =
+  let node_set = Graph.get_all_nodes graph in
+  let expected_nodes = List.map (fun (node, _) -> node) expected_annots in
+  Test_aux.check_set expected_nodes node_set;
+  List.iter
+    (fun (node, expected_annot) -> 
+       let actual_annot = Graph.get_annot graph node in
+       OUnit2.assert_equal expected_annot actual_annot)
+    expected_annots
+;;
+
+
+let tests = OUnit2.(>:::) "graph_test" [
+
+    OUnit2.(>::) "test_create_nodes" (fun _ ->
+        let graph = Graph.empty_graph () in
+        let graph, n1 = Graph.create_node graph 1 in
+        let graph, n2 = Graph.create_node graph 2 in
+
+        (* annotations should match what's given during creation
+         * all and only created nodes should be in the graph *)
+        _check_nodes_and_annots graph [(n1, 1); (n2, 2)];
+      );
+
+    OUnit2.(>::) "test_remove_nodes" (fun _ ->
+        (* 1<--->2
+         * |    /^
+         * |   / |
+         * v v   |
+         * 3     4
+         *)
+        let graph = Graph.empty_graph () in
+        let graph, n1 = Graph.create_node graph 1 in
+        let graph, n2 = Graph.create_node graph 2 in
+        let graph, n3 = Graph.create_node graph 3 in
+        let graph, n4 = Graph.create_node graph 4 in
+        let graph = _add_edges graph [(n1, n2); (n1, n3);
+                                      (n2, n1); (n2, n3); (n4, n2)]
+        in
+
+        (* remove a node without in_neighbors
+         *
+         * 1<--->2
+         * |    /
+         * |   / 
+         * v v   
+         * 3     
+         *)
+        let graph = Graph.remove_node graph n4 in
+        _check_nodes_and_annots graph [(n1, 1); (n2, 2); (n3, 3)];
+        _check_edges graph [(n1, [n2; n3]); (n2, [n1; n3]); (n3, [])];
+
+        (* remove a node without out_neighbors
+         *
+         * 1<--->2
+         *)
+        let graph = Graph.remove_node graph n3 in
+        _check_nodes_and_annots graph [(n1, 1); (n2, 2)];
+        _check_edges graph [(n1, [n2]); (n2, [n1])];
+
+        (* remove a node with mutual connection
+         *
+         * 1
+         *)
+        let graph = Graph.remove_node graph n2 in
+        _check_nodes_and_annots graph [(n1, 1)];
+      );
+
+    OUnit2.(>::) "test_get_set_annot" (fun _ ->
+        let graph = Graph.empty_graph () in
+        let graph, n1 = Graph.create_node graph 1 in
+        let graph, n2 = Graph.create_node graph 2 in
+        let graph = Graph.set_annot graph n1 11 in
+        let graph = Graph.set_annot graph n2 22 in
+
+        (* [set_annot] shouldn't change nodes themselves in the graph *)
+        _check_nodes_and_annots graph [(n1, 11); (n2, 22)];
+      );
+
+    OUnit2.(>::) "test_add_edge" (fun _ ->
+        (* 1 --> 2
+         * |    ^
+         * |   /
+         * v v
+         * 3 
+         *)
+        let graph = Graph.empty_graph () in
+        let graph, n1 = Graph.create_node graph 1 in
+        let graph, n2 = Graph.create_node graph 2 in
+        let graph, n3 = Graph.create_node graph 3 in
+        let graph = _add_edges graph [(n1, n2); (n1, n3); (n2, n3); (n3, n2)] in
+
+        (* annotation or nodes shouldn't be changed after adding edges *)
+        _check_nodes_and_annots graph [(n1, 1); (n2, 2); (n3, 3)];
+
+        (* edges should be reflected via neighbor querying functions *)
+        _check_edges graph [(n1, [n2; n3]); (n2, [n3]); (n3, [n2])]
+      );
+
+    OUnit2.(>::) "test_map" (fun _ ->
+        let graph = Graph.empty_graph () in
+        let graph, n1 = Graph.create_node graph 1 in
+        let graph, n2 = Graph.create_node graph 2 in
+        let graph = Graph.map Int.to_string graph in
+
+        (* Previously created nodes should be usable in the mapped graph.
+         * Nodes themselves should be unchanged in the mapped graph *)
+        _check_nodes_and_annots graph [(n1, "1"); (n2, "2")];
+      );
+  ]
+
+let _ =
+  OUnit2.run_test_tt_main tests

--- a/test/backend/vasm_test.ml
+++ b/test/backend/vasm_test.ml
@@ -1,0 +1,214 @@
+open Pervasives
+
+(* convenience constructors for vasm instructions *)
+
+let _temps_to_set (temps : Temp.t list) : Temp.t Set.t =
+  List.fold_right Set.add temps (Set.empty Temp.compare)
+;;
+
+let _mk_instr
+    (reads : Temp.t list) (writes : Temp.t list) (jump : Vasm.jump option)
+  : Vasm.t =
+  Vasm.Instr
+    { reads = _temps_to_set reads;
+      writes = _temps_to_set writes;
+      jump }
+;;
+
+let _mk_instr_no_jump (reads : Temp.t list) (writes : Temp.t list) : Vasm.t =
+  _mk_instr reads writes None
+;;
+
+let _mk_instr_dir_jump
+    (reads : Temp.t list) (writes : Temp.t list) (target : Label.t) : Vasm.t =
+  let jump = { Vasm.target; kind = Unconditional } in
+  _mk_instr reads writes (Some jump)
+;;
+
+let _mk_instr_cond_jump
+    (reads : Temp.t list) (writes : Temp.t list) (target : Label.t) : Vasm.t =
+  let jump = { Vasm.target; kind = Conditional } in
+  _mk_instr reads writes (Some jump)
+;;
+
+let _mk_call (reads : Temp.t list) : Vasm.t =
+  Vasm.Call (_temps_to_set reads)
+;;
+
+let _mk_label (label : Label.t) : Vasm.t =
+  Vasm.Label label
+;;
+
+
+(* property checks on cfg (incomprehensive)
+ * - no internal jumps or labels (besides first and last)
+ * - empty node should have <= 1 in and <= 1 out neighbors
+ * - last instr (check target block when applicable)
+ *  - uncond jump --> <= 1 out-edge
+ *  - cond jump   --> <= 2 out-edge
+ *  - no jump     --> <= 1 out-edge *)
+let _check_cfg_properties (cfg : Vasm.t list Graph.t) : unit =
+  let _is_first_vasm_label
+      (expect : Label.t option) (vasms : Vasm.t list) : bool =
+    match vasms with
+    | [Label actual] -> 
+      begin
+        match expect with
+        | None -> true
+        | Some expect ->
+          (Label.to_string expect) = (Label.to_string actual)
+      end
+    | _ -> false
+  in
+  let _check_last_vasm_no_jump node : unit =
+    match Set.to_list (Graph.get_out_neighbors cfg node) with
+    | [] -> () (* last instr in the entire cfg *)
+    | [next_node] -> 
+      OUnit2.assert_bool
+        "_check_last_vasm_no_jump"
+        (_is_first_vasm_label None (Graph.get_annot cfg next_node))
+    | _ -> OUnit2.assert_failure "_check_last_vasm_no_jump"
+  in
+  let _check_last_vasm_dir_jump node (target : Label.t) : unit =
+    match Set.to_list (Graph.get_out_neighbors cfg node) with
+    | [] -> () (* external jump *)
+    | [next_node] ->
+      let next_block_vasms = Graph.get_annot cfg next_node in
+      OUnit2.assert_bool
+        "_check_last_vasm_dir_jump"
+        (_is_first_vasm_label (Some target) next_block_vasms)
+    | _ -> OUnit2.assert_failure "_check_last_vasm_dir_jump"
+  in
+  let _check_last_vasm_cond_jump node (target : Label.t) : unit =
+    match Set.to_list (Graph.get_out_neighbors cfg node) with
+    | [] -> () (* external jump and last instr *)
+    | [_] -> () (* external jump or last instr *)
+    | next_node1::[next_node2] ->
+      let next_block_vasms1 = Graph.get_annot cfg next_node1 in
+      let next_block_vasms2 = Graph.get_annot cfg next_node2 in
+      OUnit2.assert_bool
+        "_check_last_vasm_cond_jump"
+        ((_is_first_vasm_label (Some target) next_block_vasms1) ||
+         (_is_first_vasm_label (Some target) next_block_vasms2))
+    | _ -> OUnit2.assert_failure "_check_last_vasm_cond_jump"
+  in
+  let _check_last_instr_in_block node (instr : Vasm.instr) : unit =
+    match instr.jump with
+    | None -> _check_last_vasm_no_jump node
+    | Some jump ->
+      match jump.kind with
+      | Unconditional -> _check_last_vasm_dir_jump node jump.target
+      | Conditional   -> _check_last_vasm_cond_jump node jump.target
+  in
+  let _check_last_vasm_in_block node (prev : Vasm.t) : unit =
+    match prev with
+    | Call _ | Label _ -> ()
+    | Instr instr -> _check_last_instr_in_block node instr
+  in
+  let rec _check_block_vasms
+      node (prev : Vasm.t) (block_vasms : Vasm.t list)
+    : unit =
+    match block_vasms with
+    | [] -> _check_last_vasm_in_block node prev
+    | (Call reads)::rest -> _check_block_vasms node (Call reads) rest
+    | (Label _)::_ ->
+      OUnit2.assert_failure "label must be at the start of a cfg block"
+    | (Instr instr)::rest ->
+      match instr.jump with
+      | Some _ ->
+        OUnit2.assert_equal
+          ~msg: "jump must be at the end of a cfg block" rest []
+      | None -> _check_block_vasms node (Instr instr) rest
+  in
+  let _check_cfg_node (node : Graph.node) : unit =
+    let block_vasms = Graph.get_annot cfg node in
+    match block_vasms with
+    | [] -> (* no in-neighbor if the block follows a direct jump *)
+      OUnit2.assert_bool "expected <= 1 in-neighbor" 
+        (Set.size (Graph.get_in_neighbors cfg node) <= 1);
+      OUnit2.assert_bool "expected <= 1 out-neighbor" 
+        (Set.size (Graph.get_out_neighbors cfg node) <= 1);
+    | first_vasm::rest_vasms ->
+      _check_block_vasms node first_vasm rest_vasms
+  in
+  List.iter _check_cfg_node (Set.to_list (Graph.get_all_nodes cfg))
+;;
+
+
+(* example temps and labels for convenience *)
+let t0, t1, t2, t3 =
+  let temp_manager, t0 = Temp.gen Temp.init_manager in
+  let temp_manager, t1 = Temp.gen temp_manager in
+  let temp_manager, t2 = Temp.gen temp_manager in
+  let _, t3            = Temp.gen temp_manager in
+  (t0, t1, t2, t3)
+;;
+
+let l0, l1, l2 = 
+  let label_manager, l0 = Label.gen Label.init_manager "L" in
+  let label_manager, l1 = Label.gen label_manager "L" in
+  let _, l2             = Label.gen label_manager "L" in
+  (l0, l1, l2)
+;;
+
+
+let tests = OUnit2.(>:::) "vasm_test" [
+
+    OUnit2.(>::) "test_get_reads_writes" (fun _ ->
+        let instr_no_jump   = _mk_instr_no_jump   [t0; t2] [t0; t1]    in
+        let instr_dir_jump  = _mk_instr_dir_jump  []       [t2; t3] l0 in
+        let instr_cond_jump = _mk_instr_cond_jump [t2; t1] []       l1 in
+        let call_no_read    = _mk_call [] in
+        let call_with_read  = _mk_call [t0; t3] in
+        let label           = _mk_label l0 in
+
+        Test_aux.check_set [t0; t2] (Vasm.get_reads instr_no_jump);
+        Test_aux.check_set []       (Vasm.get_reads instr_dir_jump);
+        Test_aux.check_set [t2; t1] (Vasm.get_reads instr_cond_jump);
+        Test_aux.check_set []       (Vasm.get_reads call_no_read);
+        Test_aux.check_set [t0; t3] (Vasm.get_reads call_with_read);
+        Test_aux.check_set []       (Vasm.get_reads label);
+
+        Test_aux.check_set [t0; t1] (Vasm.get_writes instr_no_jump);
+        Test_aux.check_set [t2; t3] (Vasm.get_writes instr_dir_jump);
+        Test_aux.check_set []       (Vasm.get_writes instr_cond_jump);
+        Test_aux.check_set []       (Vasm.get_writes call_no_read);
+        Test_aux.check_set []       (Vasm.get_writes call_with_read);
+        Test_aux.check_set []       (Vasm.get_writes label);
+      );
+
+    OUnit2.(>::) "test_build_cfg" (fun _ ->
+        (* L0:
+         *    instr        # filler
+         *    cond_jump L1 # forward jump with condition, jump after label
+         *    call         # call after jump
+         *    dir_jump L2  # external jump
+         * L1:             # label after jump
+         *    dir_jump L0  # backward jump w/o condition
+         *    instr        # instr after jump
+         *
+         * NOTE reads and writes shouldn't matter for control flow *)
+        let vasms =
+          [
+            _mk_label l0;
+            _mk_instr_no_jump [t1] [t2];
+            _mk_instr_cond_jump [t3] [t3] l1;
+            _mk_call [t0];
+            _mk_instr_dir_jump [t2; t3] [] l2;
+            _mk_label l1;
+            _mk_instr_dir_jump [] [t1; t3] l0;
+            _mk_instr_no_jump [] [];
+          ]
+        in
+        let cfg, ordered_nodes = Vasm.build_cfg vasms in
+        let vasms_from_cfg = List.map (Graph.get_annot cfg) ordered_nodes
+                              |> List.flatten in
+        OUnit2.assert_equal
+          ~cmp:(Test_aux.list_equal Test_aux.vasm_equal)
+          vasms vasms_from_cfg;
+        _check_cfg_properties cfg;
+      );
+  ]
+
+let _ =
+  OUnit2.run_test_tt_main tests

--- a/test/dune
+++ b/test/dune
@@ -9,7 +9,7 @@
    substs_test
 
    ; backend
-   cir_test temp_test label_test graph_test
+   cir_test temp_test label_test graph_test vasm_test
 
    ; helper functions
    test_aux

--- a/test/dune
+++ b/test/dune
@@ -9,7 +9,7 @@
    substs_test
 
    ; backend
-   cir_test temp_test label_test graph_test vasm_test
+   cir_test temp_test label_test graph_test vasm_test liveness_analysis_test
 
    ; helper functions
    test_aux

--- a/test/dune
+++ b/test/dune
@@ -9,7 +9,7 @@
    substs_test
 
    ; backend
-   cir_test temp_test label_test
+   cir_test temp_test label_test graph_test
 
    ; helper functions
    test_aux

--- a/test/stdlib/map_test.ml
+++ b/test/stdlib/map_test.ml
@@ -64,23 +64,20 @@ let tests = OUnit2.(>:::) "map_tests" [
       );
 
     OUnit2.(>::) "test_fold" (fun _ ->
-        let s2 = from_list [(42, 'a'); (1, 'b')] int_cmp in
+        let elem_pairs = [(42, 'a'); (1, 'b')] in
+        let s2 = from_list elem_pairs int_cmp in
         let f v acc = v::acc in
+        let values = List.map (fun (_, v) -> v) elem_pairs in
         OUnit2.assert_equal [] (Map.fold f emp_int []);
-        let res = Map.fold f s2 [] in
-        OUnit2.assert_equal 2 (List.length res);
-        OUnit2.assert_equal true (List.mem 'a' res);
-        OUnit2.assert_equal true (List.mem 'b' res);
+        Test_aux.check_unordered_list values (Map.fold f s2 []);
       );
 
     OUnit2.(>::) "test_foldi" (fun _ ->
-        let s2 = from_list [(42, 'a'); (1, 'b')] int_cmp in
+        let elem_pairs = [(42, 'a'); (1, 'b')] in
+        let s2 = from_list elem_pairs int_cmp in
         let f k v acc = (k, v)::acc in
         OUnit2.assert_equal [] (Map.foldi f emp_int []);
-        let res = Map.foldi f s2 [] in
-        OUnit2.assert_equal 2 (List.length res);
-        OUnit2.assert_equal true (List.mem (42, 'a') res);
-        OUnit2.assert_equal true (List.mem (1, 'b') res);
+        Test_aux.check_unordered_list elem_pairs (Map.foldi f s2 [])
       );
 
     OUnit2.(>::) "test_to_string" (fun _ ->
@@ -93,10 +90,7 @@ let tests = OUnit2.(>:::) "map_tests" [
 
     OUnit2.(>::) "test_get_key_set" (fun _ ->
         let s2 = from_list [(42, 'a'); (1, 'b')] int_cmp in
-        let keys = Map.get_key_set s2 in
-        OUnit2.assert_equal 2 (Set.size keys);
-        OUnit2.assert_equal true (Set.mem 42 keys);
-        OUnit2.assert_equal true (Set.mem 1 keys);
+        Test_aux.check_set [42; 1] (Map.get_key_set s2);
       );
   ]
 

--- a/test/stdlib/map_test.ml
+++ b/test/stdlib/map_test.ml
@@ -90,6 +90,14 @@ let tests = OUnit2.(>:::) "map_tests" [
         OUnit2.assert_equal "{(42, a); (1, b)}"
           (Map.to_string Int.to_string Char.to_string s2);
       );
+
+    OUnit2.(>::) "test_get_key_set" (fun _ ->
+        let s2 = from_list [(42, 'a'); (1, 'b')] int_cmp in
+        let keys = Map.get_key_set s2 in
+        OUnit2.assert_equal 2 (Set.size keys);
+        OUnit2.assert_equal true (Set.mem 42 keys);
+        OUnit2.assert_equal true (Set.mem 1 keys);
+      );
   ]
 
 let _ =

--- a/test/stdlib/set_test.ml
+++ b/test/stdlib/set_test.ml
@@ -61,21 +61,14 @@ let tests = OUnit2.(>:::) "set_tests" [
     OUnit2.(>::) "test_map" (fun _ ->
         let double n = n + n in
         let s2 = from_list [1; 42] int_cmp in
-        let s2 = Set.map double s2 in
-        OUnit2.assert_equal 0 (Set.size (Set.map double emp_int));
-        OUnit2.assert_equal 2 (Set.size s2);
-        OUnit2.assert_equal false (Set.mem 1 s2);
-        OUnit2.assert_equal true (Set.mem 2 s2);
-        OUnit2.assert_equal false (Set.mem 42 s2);
-        OUnit2.assert_equal true (Set.mem 84 s2);
+        Test_aux.check_set [] (Set.map double emp_int);
+        Test_aux.check_set [2; 84] (Set.map double s2);
       );
 
     OUnit2.(>::) "test_filter" (fun _ ->
         let s = from_list [1; 42; 22; 25] int_cmp in
         let even_s = Set.filter (fun n -> n mod 2 = 0) s in 
-        OUnit2.assert_equal 2 (Set.size even_s);
-        OUnit2.assert_equal true (Set.mem 42 even_s);
-        OUnit2.assert_equal true (Set.mem 22 even_s);
+        Test_aux.check_set [42; 22] even_s;
       );
 
     OUnit2.(>::) "test_find" (fun _ ->
@@ -87,41 +80,27 @@ let tests = OUnit2.(>:::) "set_tests" [
 
     OUnit2.(>::) "test_fold" (fun _ ->
         let s = from_list [1; 42; 11] int_cmp in
-        let l = Set.fold (fun l x -> x::l) [] s in
-        OUnit2.assert_equal 3 (List.length l);
-        OUnit2.assert_equal true (List.mem 11 l);
-        OUnit2.assert_equal true (List.mem 1 l);
-        OUnit2.assert_equal true (List.mem 42 l);
+        Test_aux.check_unordered_list
+          [1; 42; 11]
+          (Set.fold (fun l x -> x::l) [] s)
       );
 
     OUnit2.(>::) "test_union" (fun _ ->
         let s2 = from_list [1; 42] int_cmp in
         let s3 = from_list [42; 5; 7;] int_cmp in
-        let s4 = Set.union s2 s3 in
-        OUnit2.assert_equal 0 (Set.size (Set.union emp_int emp_int));
-        OUnit2.assert_equal 3 (Set.size (Set.union s3 emp_int));
-        OUnit2.assert_equal 2 (Set.size (Set.union emp_int s2));
-        OUnit2.assert_equal 4 (Set.size s4);
-        OUnit2.assert_equal true (Set.mem 1 s4);
-        OUnit2.assert_equal true (Set.mem 5 s4);
-        OUnit2.assert_equal true (Set.mem 7 s4);
-        OUnit2.assert_equal true (Set.mem 42 s4);
-        OUnit2.assert_equal false (Set.mem 0 s4);
+        Test_aux.check_set [] (Set.union emp_int emp_int);
+        Test_aux.check_set [42; 5; 7] (Set.union s3 emp_int);
+        Test_aux.check_set [42; 1] (Set.union emp_int s2);
+        Test_aux.check_set [1; 42; 5; 7] (Set.union s2 s3);
       );
 
     OUnit2.(>::) "test_inter" (fun _ ->
         let s4 = from_list [33; 11; 1; 42] int_cmp in
         let s3 = from_list [42; 7; 11;] int_cmp in
-        let s2 = Set.inter s4 s3 in
-        OUnit2.assert_equal 0 (Set.size (Set.inter emp_int emp_int));
-        OUnit2.assert_equal 0 (Set.size (Set.inter s3 emp_int));
-        OUnit2.assert_equal 0 (Set.size (Set.inter emp_int s2));
-        OUnit2.assert_equal 2 (Set.size s2);
-        OUnit2.assert_equal true (Set.mem 11 s2);
-        OUnit2.assert_equal true (Set.mem 42 s2);
-        OUnit2.assert_equal false (Set.mem 1 s2);
-        OUnit2.assert_equal false (Set.mem 7 s2);
-        OUnit2.assert_equal false (Set.mem 33 s2);
+        Test_aux.check_set [] (Set.inter emp_int emp_int);
+        Test_aux.check_set [] (Set.inter s3 emp_int);
+        Test_aux.check_set [] (Set.inter emp_int s4);
+        Test_aux.check_set [11; 42] (Set.inter s4 s3);
       );
 
     OUnit2.(>::) "test_disjoint" (fun _ ->
@@ -144,25 +123,11 @@ let tests = OUnit2.(>:::) "set_tests" [
     OUnit2.(>::) "test_diff" (fun _ ->
         let s4 = from_list [33; 11; 1; 42] int_cmp in
         let s3 = from_list [42; 7; 11;] int_cmp in
-        OUnit2.assert_equal 0 (Set.size (Set.diff emp_int emp_int));
-        OUnit2.assert_equal 3 (Set.size (Set.diff s3 emp_int));
-        OUnit2.assert_equal 0 (Set.size (Set.diff emp_int s4));
-
-        let s1 = Set.diff s3 s4 in
-        OUnit2.assert_equal 1 (Set.size s1);
-        OUnit2.assert_equal true (Set.mem 7 s1);
-        OUnit2.assert_equal false (Set.mem 42 s1);
-        OUnit2.assert_equal false (Set.mem 11 s1);
-        OUnit2.assert_equal false (Set.mem 33 s1);
-        OUnit2.assert_equal false (Set.mem 1 s1);
-
-        let s2 = Set.diff s4 s3 in
-        OUnit2.assert_equal 2 (Set.size s2);
-        OUnit2.assert_equal true (Set.mem 33 s2);
-        OUnit2.assert_equal true (Set.mem 1 s2);
-        OUnit2.assert_equal false (Set.mem 7 s2);
-        OUnit2.assert_equal false (Set.mem 42 s2);
-        OUnit2.assert_equal false (Set.mem 11 s2);
+        Test_aux.check_set []          (Set.diff emp_int emp_int);
+        Test_aux.check_set [42; 7; 11] (Set.diff s3 emp_int);
+        Test_aux.check_set []          (Set.diff emp_int s4);
+        Test_aux.check_set [7]         (Set.diff s3 s4);
+        Test_aux.check_set [33; 1]     (Set.diff s4 s3);
       );
 
     OUnit2.(>::) "test_subset" (fun _ ->
@@ -182,12 +147,8 @@ let tests = OUnit2.(>:::) "set_tests" [
 
     OUnit2.(>::) "test_to_list" (fun _ ->
         let s3 = from_list [11; 11; 1; 42; 1; 42] int_cmp in
-        let l3 = Set.to_list s3 in
-        OUnit2.assert_equal [] (Set.to_list emp_int);
-        OUnit2.assert_equal 3 (List.length l3);
-        OUnit2.assert_equal true (List.mem 11 l3);
-        OUnit2.assert_equal true (List.mem 1 l3);
-        OUnit2.assert_equal true (List.mem 42 l3);
+        Test_aux.check_unordered_list [] (Set.to_list emp_int);
+        Test_aux.check_unordered_list [11; 1; 42] (Set.to_list s3);
       );
 
     OUnit2.(>::) "test_to_string" (fun _ ->

--- a/test/stdlib/set_test.ml
+++ b/test/stdlib/set_test.ml
@@ -30,6 +30,25 @@ let tests = OUnit2.(>:::) "set_tests" [
         OUnit2.assert_equal 1 (Set.size (Set.remove 42 s2));
       );
 
+    OUnit2.(>::) "test_get_one" (fun _ ->
+        let _check_get_one (set : int Set.t) : unit =
+          match Set.get_one set with
+          | None ->
+            OUnit2.assert_bool
+              "Non-empty set returned nothing"
+              ((Set.size set) = 0)
+          | Some n ->
+            OUnit2.assert_bool
+              "get_one should return a member of set"
+              (Set.mem n set)
+        in
+        let s1 = from_list [42] int_cmp in
+        let s2 = from_list [1; 42] int_cmp in
+        _check_get_one emp_int;
+        _check_get_one s1;
+        _check_get_one s2;
+      );
+
     OUnit2.(>::) "test_mem" (fun _ ->
         let s2 = from_list [42; 1; 42] int_cmp in
         OUnit2.assert_equal false (Set.mem 42 emp_int);
@@ -49,6 +68,30 @@ let tests = OUnit2.(>:::) "set_tests" [
         OUnit2.assert_equal true (Set.mem 2 s2);
         OUnit2.assert_equal false (Set.mem 42 s2);
         OUnit2.assert_equal true (Set.mem 84 s2);
+      );
+
+    OUnit2.(>::) "test_filter" (fun _ ->
+        let s = from_list [1; 42; 22; 25] int_cmp in
+        let even_s = Set.filter (fun n -> n mod 2 = 0) s in 
+        OUnit2.assert_equal 2 (Set.size even_s);
+        OUnit2.assert_equal true (Set.mem 42 even_s);
+        OUnit2.assert_equal true (Set.mem 22 even_s);
+      );
+
+    OUnit2.(>::) "test_find" (fun _ ->
+        let s = from_list [42; 1; 22; 25] int_cmp in
+        OUnit2.assert_equal None (Set.find (fun n -> n = 2) s);
+        OUnit2.assert_equal (Some 1) (Set.find (fun n -> n = 1) s);
+        OUnit2.assert_equal (Some 22) (Set.find (fun n -> n = 22) s);
+      );
+
+    OUnit2.(>::) "test_fold" (fun _ ->
+        let s = from_list [1; 42; 11] int_cmp in
+        let l = Set.fold (fun l x -> x::l) [] s in
+        OUnit2.assert_equal 3 (List.length l);
+        OUnit2.assert_equal true (List.mem 11 l);
+        OUnit2.assert_equal true (List.mem 1 l);
+        OUnit2.assert_equal true (List.mem 42 l);
       );
 
     OUnit2.(>::) "test_union" (fun _ ->
@@ -151,6 +194,21 @@ let tests = OUnit2.(>:::) "set_tests" [
         let s4 = from_list [33; 11; 1; 42] int_cmp in
         OUnit2.assert_equal "{}" (Set.to_string Int.to_string emp_int);
         OUnit2.assert_equal "{33; 11; 1; 42}" (Set.to_string Int.to_string s4);
+      );
+
+    OUnit2.(>::) "test_get_compare_func" (fun _ ->
+        let lt = Int.compare in
+        let gt = (fun n1 n2 -> -(Int.compare n1 n2)) in
+        let slt = from_list [33; 11; 1; 42] lt in
+        let sgt = from_list [33; 11; 1; 42] gt in
+        let slt_func = Set.get_compare_func slt in
+        let sgt_func = Set.get_compare_func sgt in
+        OUnit2.assert_equal true ((slt_func 0 2) < 0);
+        OUnit2.assert_equal true ((slt_func 1 1) = 0);
+        OUnit2.assert_equal true ((slt_func 3 1) > 0);
+        OUnit2.assert_equal true ((sgt_func 3 1) < 0);
+        OUnit2.assert_equal true ((sgt_func 1 1) = 0);
+        OUnit2.assert_equal true ((sgt_func 0 2) > 0);
       );
   ]
 

--- a/test/test_aux.ml
+++ b/test/test_aux.ml
@@ -35,13 +35,14 @@ let check_unordered_list (expects : 'a list) (actuals : 'a list) : unit =
     expects
 ;;
 
+(* TODO move to Set module *)
+let set_equal (s1 : 'a Set.t) (s2 : 'a Set.t) : bool =
+  let s1_size = Set.size s1 in
+  (s1_size = Set.size s2) &&
+  (Set.size (Set.union s1 s2) = s1_size)
+;;
+
 let vasm_equal (v1 : Vasm.t) (v2 : Vasm.t) : bool =
-  (* TODO move to Set module *)
-  let set_equal (s1 : 'a Set.t) (s2 : 'a Set.t) : bool =
-    let s1_size = Set.size s1 in
-    (s1_size = Set.size s2) &&
-    (Set.size (Set.union s1 s2) = s1_size)
-  in
   match v1, v2 with
   | Call reads1, Call reads2 ->
     set_equal reads1 reads2

--- a/test/test_aux.ml
+++ b/test/test_aux.ml
@@ -1,3 +1,4 @@
+open Pervasives
 
 (** [check_and_output_str str ref_path output_path] checks whether [str] matches
     the content of the file at [ref_path], and (over)writes [str] to
@@ -8,4 +9,28 @@ let check_and_output_str str ref_path output_path =
   Stdlib.close_out output;
   let ref_str = Externals.read_entire_file ref_path in
   OUnit2.assert_equal ref_str str;
+;;
+
+(** [check_set expects actuals] makes sure
+    - [expects] and [actuals] contain the same # of elements
+    - All elements from [expects] are in [actuals] *)
+let check_set (expects : 'a list) (actuals : 'a Set.t) : unit =
+  OUnit2.assert_equal (List.length expects) (Set.size actuals);
+  List.iter
+    (fun elem -> 
+      OUnit2.assert_equal true (Set.mem elem actuals))
+    expects
+;;
+
+(** [check_set expects actuals] makes sure
+    - [expects] and [actuals] contain the same # of elements
+    - All elements from [expects] are in [actuals] 
+    NOTE intentionally separated from [check_set] because I want to use the
+    right [mem] function for testing. *)
+let check_unordered_list (expects : 'a list) (actuals : 'a list) : unit =
+  OUnit2.assert_equal (List.length expects) (List.length actuals);
+  List.iter
+    (fun elem -> 
+      OUnit2.assert_equal true (List.mem elem actuals))
+    expects
 ;;

--- a/test/test_aux.ml
+++ b/test/test_aux.ml
@@ -34,3 +34,36 @@ let check_unordered_list (expects : 'a list) (actuals : 'a list) : unit =
       OUnit2.assert_equal true (List.mem elem actuals))
     expects
 ;;
+
+let vasm_equal (v1 : Vasm.t) (v2 : Vasm.t) : bool =
+  (* TODO move to Set module *)
+  let set_equal (s1 : 'a Set.t) (s2 : 'a Set.t) : bool =
+    let s1_size = Set.size s1 in
+    (s1_size = Set.size s2) &&
+    (Set.size (Set.union s1 s2) = s1_size)
+  in
+  match v1, v2 with
+  | Call reads1, Call reads2 ->
+    set_equal reads1 reads2
+
+  | Label l1, Label l2 ->
+    (Label.to_string l1) = (Label.to_string l2)
+
+  | Instr instr1, Instr instr2 ->
+    (set_equal instr1.reads instr2.reads) &&
+    (set_equal instr1.writes instr2.writes) &&
+    instr1.jump = instr2.jump
+
+  | _ -> false
+;;
+
+(* TODO move to list module *)
+let rec list_equal (cmp : 'a -> 'a -> bool) (l1 : 'a list) (l2 : 'a list)
+  : bool =
+  match l1, l2 with
+  | [], [] -> true
+  | [], _  -> false
+  | _, []  -> false
+  | x1::l1, x2::l2 ->
+    (cmp x1 x2) && (list_equal cmp l1 l2)
+;;


### PR DESCRIPTION
0. A `Vasm` module to represent virtual or abstract assembly instructions. Why?
   - We can use it to build control flow graph for different ISAs, e.g., X86, MIPS, etc.
   - We can use it to implement a general register allocator for different ISAs.
   - Might be able to add optimization on top of it later.

1. A `Liveness_analysis` module mainly for register allocation later.