### PR TITLE
Register Allocation

### DIFF
--- a/lib/backend/reg_alloc.ml
+++ b/lib/backend/reg_alloc.ml
@@ -1,0 +1,288 @@
+open Pervasives
+
+(* NOTE Algorithm Essential Ideas: (essentially a greedy algorithm)
+ * - First scan each call instr, pre-color all temps that live across a call to
+ *   callee-saved regs, else we must spill them.
+ * - Color each temp in live-in (e.g., args). (see below on how coloring works)
+ * - Then scan each instruction, color each temp
+ *  - allocate for read first, then write, since regs for dead read temps can
+ *    be re-used, e.g., [ADD R1, R1]
+ *  - spill when there isn't any color available.
+ *  - accumulate active temps
+ * - ignore spilled temps and continue scanning to spill as much as needed.
+ * - coloring is globally fixed once upon the first assignment
+ * - Termination: Worst case we spill everything, at which point we just need a
+ *   minimum # of regs for each operation. If we don't even have enough regs for
+ *   that, we error, because there is no possible coloring.
+ *)
+
+(* Accumulators while coloring temps in instructions *)
+type 'a context =
+  { avalb_colors : 'a Set.t     (* all available colors - colors of
+                                   [temps_in_use].
+                                   used only during coloring *)
+  ; temps_in_use : Temp.t Set.t (* live temps occupying distinct regs.
+                                   used only during coloring *) 
+    (* The followings are needed at the end *)
+  ; coloring       : (Temp.t, 'a) Map.t
+  ; temps_to_spill : Temp.t Set.t      
+  }
+
+let _ctx_init
+    (avalb_colors : 'a Set.t)
+    (coloring : (Temp.t, 'a) Map.t)
+    (temps_to_spill : Temp.t Set.t)
+  : 'a context =
+  { avalb_colors; coloring; temps_to_spill;
+    temps_in_use = Set.empty Temp.compare; }
+;;
+
+let _ctx_find_temp_using_color (ctx : 'a context) (color : 'a) : Temp.t =
+  let same_color c1 c2 = (Set.get_compare_func ctx.avalb_colors c1 c2) = 0 in
+  let has_color (temp : Temp.t) = 
+    match Map.get temp ctx.coloring with
+    | None ->
+      failwith "[Reg_alloc._ctx_find_temp_using_color] temp in use isn't colored"
+    | Some temp_color -> same_color temp_color color
+  in
+  match Set.find has_color ctx.temps_in_use with
+  | None ->
+    failwith "[Reg_alloc._ctx_find_temp_using_color] no active temp uses color"
+  | Some temp -> temp
+;;
+
+let _ctx_use_coloring (ctx : 'a context) (temp : Temp.t) (color : 'a)
+  : 'a context =
+  let avalb_colors = Set.remove color ctx.avalb_colors in
+  let temps_in_use = Set.add temp ctx.temps_in_use in
+  { ctx with avalb_colors; temps_in_use }
+;;
+
+let _ctx_add_active_coloring (ctx : 'a context) (temp : Temp.t) (color : 'a)
+  : 'a context =
+  let coloring = Map.add temp color ctx.coloring in
+  let ctx = { ctx with coloring } in
+  _ctx_use_coloring ctx temp color
+;;
+
+(* Spill [temp] in [ctx] and return its color; doesn't need to be in use. *)
+let _ctx_spill_temp (ctx : 'a context) (temp : Temp.t)
+  : ('a context * 'a) =
+  match Map.get temp ctx.coloring with
+  | None ->
+    failwith "[Reg_alloc._ctx_spill_temp] temp to spill should be colored"
+  | Some color ->
+    let avalb_colors = Set.add color ctx.avalb_colors in
+    let temps_in_use = Set.remove temp ctx.temps_in_use in
+    let temps_to_spill = Set.add temp ctx.temps_to_spill in
+    let ctx = { ctx with avalb_colors; temps_in_use; temps_to_spill } in
+    (ctx, color)
+;;
+
+(* [killed] won't be used anymore *)
+let _ctx_remove_dead_temps (ctx : 'a context) (killed : Temp.t Set.t)
+  : 'a context =
+  let temps_in_use = Set.diff ctx.temps_in_use killed in
+  let avalb_colors =
+    List.fold_left
+      (fun avalb_colors killed_temp ->
+         match Map.get killed_temp ctx.coloring with
+         | None ->
+           if Set.mem killed_temp ctx.temps_to_spill then avalb_colors
+           else
+             failwith 
+               (String.join_with
+                  ["[Reg_alloc._ctx_remove_killed_temps] Unspilled killed Temp "
+                  ; (Temp.to_string killed_temp); " should've been colored";] "")
+         | Some color ->
+           Set.add color avalb_colors)
+      ctx.avalb_colors (Set.to_list killed)
+  in
+  { ctx with temps_in_use; avalb_colors }
+;;
+
+(* ENSURE: Won't spill temps in [init_temps_to_color] *)
+let _ctx_distinct_color_temps
+    (ctx : 'a context) (init_temps_to_color : Temp.t Set.t)
+  : 'a context =
+  (* NOTE:
+   * Q: Why separate [can_spill] and [ctx.temps_in_use]? 
+   * A: We don't want to spill temps within the same instruction. If there's no
+   * other temp we can spill, that means we simply don't have enough regs. *)
+  let spill_and_color (ctx : 'a context)
+      (temp_to_color : Temp.t) (can_spill : Temp.t Set.t)
+    : ('a context * Temp.t Set.t) =
+    match Set.get_one can_spill with
+    | None -> failwith "[Reg_alloc._ctx_color_temps] Not enough register"
+    | Some to_spill ->
+      let ctx, color = _ctx_spill_temp ctx to_spill in
+      let can_spill = Set.remove to_spill can_spill in
+      let ctx = _ctx_add_active_coloring ctx temp_to_color color in
+      (ctx, can_spill)
+  in
+  let color_uncolored_temp (ctx : 'a context)
+      (temp_to_color : Temp.t) (can_spill : Temp.t Set.t)
+    : ('a context * Temp.t Set.t) =
+    (* pick any color, if available *)
+    match Set.get_one ctx.avalb_colors with
+    | None -> spill_and_color ctx temp_to_color can_spill
+    | Some color ->
+      let ctx = _ctx_add_active_coloring ctx temp_to_color color in
+      (ctx, can_spill)
+  in
+  let color_one_temp (ctx : 'a context)
+      (temp_to_color : Temp.t) (can_spill : Temp.t Set.t)
+    : ('a context * Temp.t Set.t) =
+    match Map.get temp_to_color ctx.coloring with
+    | None       -> color_uncolored_temp ctx temp_to_color can_spill
+    | Some color ->
+      if Set.mem color ctx.avalb_colors ||
+         Set.mem temp_to_color ctx.temps_in_use
+      then (_ctx_use_coloring ctx temp_to_color color, can_spill)
+      else (* assigned color is currently occupied by others *)
+        let temp_occupying_color = _ctx_find_temp_using_color ctx color in
+        let ctx, _ = _ctx_spill_temp ctx temp_occupying_color in
+        (_ctx_use_coloring ctx temp_to_color color, can_spill)
+  in
+  let can_spill = Set.diff ctx.temps_in_use init_temps_to_color in
+  Set.fold (* arbitrary order of coloring *)
+    (fun (ctx, can_spill) temp ->
+       if Set.mem temp ctx.temps_to_spill
+       then (ctx, can_spill) (* don't waste time on already spilled temp *)
+       else color_one_temp ctx temp can_spill)
+    (ctx, can_spill) init_temps_to_color
+  |> (fun (ctx, _) -> ctx)
+;;
+
+(* Assign distinct color to [temps] (if not colored), and free them up if not
+ * alive afterwards, i.e., absent in [live_out] *)
+let _ctx_distinct_color_temps_and_free_regs
+  (ctx : 'a context) (temps : Temp.t Set.t) (live_out : Temp.t Set.t)
+  : 'a context =
+  let ctx = _ctx_distinct_color_temps ctx temps in
+  let dead = Set.filter (fun temp -> not (Set.mem temp live_out)) temps in
+  _ctx_remove_dead_temps ctx dead
+;;
+
+(* ASSUME temps in live-in, i.e. live-out of previous instr, were handled *)
+let _brute_alloc_vasm
+  (ctx : 'a context) (vasm : Vasm.t) (annot : Liveness_analysis.annot)
+  : 'a context =
+  let reads, writes = Vasm.get_reads vasm, Vasm.get_writes vasm in
+  (* NOTE allocating reads/writes separately allows
+   * T1 := T2 + T3 to use 2 regs only, but it requires the ISA to support
+   * using same regs in src and dst *)
+  let ctx = _ctx_distinct_color_temps_and_free_regs ctx reads annot.live_out in
+  _ctx_distinct_color_temps_and_free_regs ctx writes annot.live_out
+;;
+
+let _brute_alloc_impl
+    (ctx : 'a context)
+    (annot_instrs   : (Vasm.t * Liveness_analysis.annot) list)
+  : 'a context =
+  match annot_instrs with
+  | [] -> ctx
+  | (_, annot)::_ ->
+    (* Handle temps alive before 1st instr, think function args.
+     * [arg1, ..., argn] := ...
+     * All written, all alive (in the live-out of this imaginary init instr) *)
+    let live_in = annot.live_in in
+    let ctx = _ctx_distinct_color_temps_and_free_regs ctx live_in live_in in
+    List.fold_left
+      (fun ctx (instr, annot) -> _brute_alloc_vasm ctx instr annot)
+      ctx annot_instrs
+;;
+
+let _brute_color_temps_live_across_call
+    (init_coloring : (Temp.t, 'a) Map.t) (init_temps_to_spill : Temp.t Set.t)
+    (callee_saved : 'a Set.t) (vasm : Vasm.t) (annot : Liveness_analysis.annot) 
+  : ((Temp.t, 'a) Map.t * Temp.t Set.t) =
+
+  let extract_colored_temps temp_set
+    : ((Temp.t * 'a) list * Temp.t list) =
+    Set.fold
+      (fun (temp_color_pairs, uncolored_temps) temp ->
+         match Map.get temp init_coloring with
+         | Some color -> ((temp, color)::temp_color_pairs, uncolored_temps)
+         | None       -> (temp_color_pairs, temp::uncolored_temps))
+      ([], []) temp_set
+  in
+
+  let add_temps_colored_to_caller_saved temp_set (coloring : (Temp.t * 'a) list)
+    : Temp.t Set.t =
+    List.fold_left 
+      (fun temps_to_spill (temp, color) ->
+         if Set.mem color callee_saved then temps_to_spill
+         else Set.add temp temps_to_spill)
+      temp_set coloring
+  in
+
+  let color_to_callee_saved_or_spill
+      (coloring : (Temp.t, 'a) Map.t)
+      (temps_to_spill : Temp.t Set.t)
+      (temps_to_color : Temp.t list)
+    : (Temp.t, 'a) Map.t * Temp.t Set.t =
+    List.fold_left (* color the rest to callee-saved, as much as possible *)
+      (fun (avalb_colors, pre_colored, temps_to_spill) temp ->
+         match Set.get_one avalb_colors with
+         | Some color -> 
+           if Set.mem temp temps_to_spill
+           then (avalb_colors, pre_colored, temps_to_spill)
+           else
+             let avalb_colors = Set.remove color avalb_colors in
+             let pre_colored = Map.add temp color pre_colored in
+             (avalb_colors, pre_colored, temps_to_spill)
+         (* don't waste color for already spilled temp *)
+         | _ -> (avalb_colors, pre_colored, Set.add temp temps_to_spill))
+      (callee_saved, coloring, temps_to_spill)
+      temps_to_color
+    |> (fun (_, pre_colored, temps_to_spill) -> (pre_colored, temps_to_spill))
+  in
+
+  if not (Vasm.is_call vasm) then (init_coloring, init_temps_to_spill)
+  else
+    (* Any temp that lives across a call must be mapped to callee-saved or
+     * spilled. *)
+    let temps_live_across_call = Set.inter annot.live_out annot.live_in in
+    let temp_color_pairs, temps_to_color =
+      extract_colored_temps temps_live_across_call
+    in
+    let temps_to_spill = (* must spill temps pre-colored to caller-saved *)
+      add_temps_colored_to_caller_saved init_temps_to_spill temp_color_pairs
+    in
+    color_to_callee_saved_or_spill init_coloring temps_to_spill temps_to_color
+;;
+
+(* pre-color temps that live through Call instructions to callee-saved regs *)
+let _brute_pre_color_call_temps
+    (annot_instrs : (Vasm.t * Liveness_analysis.annot) list)
+    (callee_saved : 'a Set.t)
+    (pre_colored  : (Temp.t, 'a) Map.t)
+  : ((Temp.t, 'a) Map.t * Temp.t Set.t) =
+  List.fold_left
+    (fun (pre_colored, temps_to_spill)  (instr, annot) ->
+       _brute_color_temps_live_across_call
+         pre_colored temps_to_spill callee_saved instr annot)
+    (pre_colored, Set.empty Temp.compare)
+    annot_instrs
+;;
+
+(* REQUIRES:
+ * 1. [caller_saved] and [callee_saved] are disjoint
+ * 2. anoot_instrs has accurate liveness annotation (exposed for eaiser testing)
+ *)
+let brute_alloc 
+    (annot_instrs : (Vasm.t * Liveness_analysis.annot) list)
+    (caller_saved : 'a Set.t)
+    (callee_saved : 'a Set.t)
+    (pre_colored  : (Temp.t, 'a) Map.t)
+  : ((Temp.t, 'a) Map.t, Temp.t Set.t) result =
+  let pre_colored, temps_to_spill =
+    _brute_pre_color_call_temps annot_instrs callee_saved pre_colored in
+  let all_regs = Set.union caller_saved callee_saved in
+  let ctx = _ctx_init all_regs pre_colored temps_to_spill in
+  let ctx = _brute_alloc_impl ctx annot_instrs in
+  if Set.size ctx.temps_to_spill = 0
+  then Ok ctx.coloring
+  else Error ctx.temps_to_spill
+;;

--- a/lib/backend/reg_alloc.ml
+++ b/lib/backend/reg_alloc.ml
@@ -271,7 +271,7 @@ let _brute_pre_color_call_temps
  * 1. [caller_saved] and [callee_saved] are disjoint
  * 2. anoot_instrs has accurate liveness annotation (exposed for eaiser testing)
  *)
-let brute_alloc 
+let greedy_alloc 
     (annot_instrs : (Vasm.t * Liveness_analysis.annot) list)
     (caller_saved : 'a Set.t)
     (callee_saved : 'a Set.t)

--- a/lib/backend/reg_alloc.mli
+++ b/lib/backend/reg_alloc.mli
@@ -1,13 +1,20 @@
 open Pervasives
 
-(** [brute_alloc instr_annot_pair caller_saved callee_saved pre_colored] returns 
- *
+(** [greedy_alloc instr_annot_pair caller_saved callee_saved pre_colored] returns 
+  
     - Ok: a valid coloring for instructions in instr_annot_pair. It's guaranteed
       to be a "super-map" of [pre_colored]
 
     - Error: A set of temps that should be spilled (may spill more or less than
-      what's needed, but repeated application will ensure termination, I hope) *)
-val brute_alloc :
+      what's needed, but repeated application will ensure termination, I hope) 
+
+    It's greedy because it linear scans all the instructions and immediately
+    assign available color to the temps, without backtracking or a global view.
+
+    NOTE Undefined behavior if 
+    - [caller_saved] and [callee_saved] sets are not disjoint, 
+    - any liveness annotation is inaccurate. *)
+val greedy_alloc :
   (Vasm.t * Liveness_analysis.annot) list ->
   'a Set.t -> 'a Set.t ->
   (Temp.t, 'a) Map.t ->

--- a/lib/backend/reg_alloc.mli
+++ b/lib/backend/reg_alloc.mli
@@ -1,0 +1,14 @@
+open Pervasives
+
+(** [brute_alloc instr_annot_pair caller_saved callee_saved pre_colored] returns 
+ *
+    - Ok: a valid coloring for instructions in instr_annot_pair. It's guaranteed
+      to be a "super-map" of [pre_colored]
+
+    - Error: A set of temps that should be spilled (may spill more or less than
+      what's needed, but repeated application will ensure termination, I hope) *)
+val brute_alloc :
+  (Vasm.t * Liveness_analysis.annot) list ->
+  'a Set.t -> 'a Set.t ->
+  (Temp.t, 'a) Map.t ->
+  ((Temp.t, 'a) Map.t, Temp.t Set.t) result

--- a/test/backend/backend_aux.ml
+++ b/test/backend/backend_aux.ml
@@ -1,0 +1,17 @@
+open Pervasives
+
+let temps_to_set temps =
+  List.fold_right Set.add temps (Set.empty Temp.compare)
+;;
+
+let mk_annotated_vasms live_in vasm_live_out_set_pairs =
+  List.fold_left
+    (fun (live_in, rev_annot_instrs) (instr, live_out) ->
+       let live_out = temps_to_set live_out in
+       let annot = { Liveness_analysis.live_in; live_out } in
+       let rev_annot_instrs = (instr, annot)::rev_annot_instrs in
+       (live_out, rev_annot_instrs))
+    (temps_to_set live_in, [])
+    vasm_live_out_set_pairs
+  |> (fun (_, rev_annot_instrs) -> List.rev rev_annot_instrs)
+;;

--- a/test/backend/backend_aux.mli
+++ b/test/backend/backend_aux.mli
@@ -1,0 +1,8 @@
+open Pervasives
+
+val temps_to_set : Temp.t list -> Temp.t Set.t
+
+val mk_annotated_vasms :
+  Temp.t list ->                 (* live-in *)
+  (Vasm.t * Temp.t list) list -> (* vasm with live-out *)
+  (Vasm.t * Liveness_analysis.annot) list

--- a/test/backend/reg_alloc_test.ml
+++ b/test/backend/reg_alloc_test.ml
@@ -1,0 +1,252 @@
+open Pervasives
+
+(* NOTE README 
+ * We use [int] to simulate physical regs and test register allocator. So a lot
+ * of the helpers here are catered to contain [int] type *)
+
+let _empty_temp_map =
+  Map.empty Temp.compare
+;;
+
+let _temp_pairs_to_map (pairs : (Temp.t * 'v) list) : (Temp.t, 'v) Map.t =
+  List.fold_left (fun map (k, v) -> Map.add k v map) _empty_temp_map pairs
+;;
+
+let _err_unexpected_spill (spills : Temp.t Set.t) : 'a =
+  let str = Set.to_string Temp.to_string spills in
+  let msg = String.append "Unexpected spill: " str in
+  OUnit2.assert_failure msg
+;;
+
+let _err_unexpected_coloring (coloring : (Temp.t, int) Map.t) : 'a =
+  let str = Map.to_string Temp.to_string Int.to_string coloring in
+  let msg = String.append "Unexpected coloring: " str in
+  OUnit2.assert_failure msg
+;;
+
+let _int_set (items : int list) : int Set.t =
+  List.fold_right Set.add items (Set.empty Int.compare)
+;;
+
+let _check_spills
+    (expect_spills : Temp.t list)
+    (result : ((Temp.t, int) Map.t, Temp.t Set.t) result) : unit =
+  match result with
+  | Error spills -> 
+    let same_length = (List.length expect_spills) = (Set.size spills) in
+    let is_subset =
+      List.for_all
+        (fun expected_temp -> Set.mem expected_temp spills)
+        expect_spills
+    in
+    let expect_str =
+      String.join_with (List.map Temp.to_string expect_spills) ", " in
+    let actual_str = Set.to_string Temp.to_string spills in
+    let error_msg =
+      String.join_with
+        ["expected: ["; expect_str; "]; actual: "; actual_str] ""
+    in
+    OUnit2.assert_bool error_msg (same_length && is_subset);
+  | Ok coloring -> _err_unexpected_coloring coloring
+;;
+
+let _check_coloring
+    (expected_coloring : (Temp.t * int) list)
+    (result : ((Temp.t, int) Map.t, Temp.t Set.t) result) : unit =
+  match result with
+  | Error spills -> _err_unexpected_spill spills
+  | Ok coloring ->
+    let same_length = (List.length expected_coloring) = (Map.size coloring) in
+    let is_subset =
+      List.for_all
+        (fun (temp, expected_color) ->
+           match Map.get temp coloring with
+           | None -> false
+           | Some actual_color -> expected_color = actual_color)
+        expected_coloring
+    in
+    let pair_strs =
+      List.map
+        (fun (temp, color) ->
+           String.join_with
+             ["("; Temp.to_string temp; ", "; Int.to_string color; ")"] "")
+        expected_coloring
+    in
+    let expect_str = String.join_with pair_strs ", " in
+    let actual_str = Map.to_string Temp.to_string Int.to_string coloring in
+    let error_msg =
+      String.join_with
+        ["expected: ["; expect_str; "]; actual: "; actual_str] ""
+    in
+    OUnit2.assert_bool error_msg (same_length && is_subset);
+;;
+
+let _check_coloring_size
+    (expect_coloring_size : int)
+    (result : ((Temp.t, int) Map.t, Temp.t Set.t) result) : unit =
+  match result with
+  | Error spills -> _err_unexpected_spill spills
+  | Ok coloring  ->
+    OUnit2.assert_equal expect_coloring_size (Map.size coloring);
+;;
+
+
+let tests = OUnit2.(>:::) "reg_alloc_test" [
+
+    OUnit2.(>::) "test_greedy_alloc_no_precolor_no_call" (fun _ ->
+        let empty_regs = _int_set [] in
+        let regs = _int_set [0; 1] in
+        let pre_colored = Map.empty Temp.compare in
+        let manager, t0 = Temp.gen Temp.init_manager in
+        let manager, t1 = Temp.gen manager in
+        let manager, t2 = Temp.gen manager in
+
+        (* allow re-using dead read regs
+         * ...            # live-out = [T1; T2]
+         * T0 := T1 + T2  # live-out = [] *)
+        let instrs = Backend_aux.mk_annotated_vasms [t1; t2]
+            [
+              (Vasm.mk_instr [t1; t2] [t0], []);
+            ]
+        in
+        (* caller/callee saved shouldn't matter for these instrs *)
+        _check_coloring [(t0, 1); (t1, 0); (t2, 1)]
+          (Reg_alloc.greedy_alloc instrs regs empty_regs pre_colored);
+        _check_coloring [(t0, 1); (t1, 0); (t2, 1)]
+          (Reg_alloc.greedy_alloc instrs empty_regs regs pre_colored);
+
+        (* spill live-in *)
+        let manager, t3 = Temp.gen manager in
+        let _, t4 = Temp.gen manager in
+        (* ...             # live-out = [T3; T4]
+         * T0 := 123       # live-out = [T0; T3; T4]
+         * T1 := 456       # live-out = [T0; T1; T3; T4]
+         * T2 := T3 + T4   # live-out = [T0, T1]
+         * T0 := T0 + T1   # live-out = [] *)
+        let instrs = Backend_aux.mk_annotated_vasms [t3; t4]
+            [
+              (Vasm.mk_instr []       [t0], [t0; t3; t4]);
+              (Vasm.mk_instr []       [t1], [t0; t1; t3; t4]);
+              (Vasm.mk_instr [t3; t4] [t2], [t0; t1]);
+              (Vasm.mk_instr [t0; t1] [t0], []);
+            ]
+        in
+        (* caller/callee saved shouldn't matter for these instrs *)
+        _check_spills [t0; t4]
+          (Reg_alloc.greedy_alloc instrs regs empty_regs pre_colored);
+        _check_spills [t0; t4]
+          (Reg_alloc.greedy_alloc instrs empty_regs regs pre_colored);
+      );
+
+    OUnit2.(>::) "test_greedy_alloc_with_precolor_no_call" (fun _ ->
+        let empty_regs = _int_set [] in
+        let regs = _int_set [0; 1; 2] in
+        let manager, t0 = Temp.gen Temp.init_manager in
+        let manager, t1 = Temp.gen manager in
+        let manager, t2 = Temp.gen manager in
+        let _, t3 = Temp.gen manager in
+        let pre_colored = _temp_pairs_to_map [(t0, 0); (t1, 1); (t2, 2)] in
+        (* ...            # live_out = []
+         * T1 = 1         # live_out = [T1]
+         * T2 = 2         # live_out = [T1, T2]
+         * T3 = 3         # live_out = [T1, T2, T3]
+         * T0 := T1 + T2  # live_out = [T0, T2, T3]
+         * T0 + T2 + T3   # live_out = []
+         * ...
+         * pre-color [T0 : 0; T1 : 1; T2 : 2] prevents T1 to reuse reg,
+         * forces spilling of T3 *)
+        let instrs = Backend_aux.mk_annotated_vasms []
+            [
+              (Vasm.mk_instr []       [t1], [t1;]);
+              (Vasm.mk_instr []       [t2], [t1; t2;]);
+              (Vasm.mk_instr []       [t3], [t1; t2; t3;]);
+              (Vasm.mk_instr [t1; t2] [t0], [t0; t2; t3;]);
+              (Vasm.mk_instr [t2; t3] [t0], []);
+            ]
+        in
+        (* caller/callee saved shouldn't matter for these instrs *)
+        _check_spills [t3]
+          (Reg_alloc.greedy_alloc instrs regs empty_regs pre_colored);
+        _check_spills [t3]
+          (Reg_alloc.greedy_alloc instrs empty_regs regs pre_colored);
+        _check_coloring [(t1, 0); (t2, 1); (t3, 2); (t0, 0)]
+          (Reg_alloc.greedy_alloc instrs regs empty_regs _empty_temp_map);
+        _check_coloring [(t1, 0); (t2, 1); (t3, 2); (t0, 0)]
+          (Reg_alloc.greedy_alloc instrs empty_regs regs _empty_temp_map);
+      );
+
+    OUnit2.(>::) "test_greedy_alloc_no_precolor_has_call" (fun _ ->
+        let callee_saved = _int_set [0; 1; 2] in
+        let caller_saved = _int_set [3] in
+        let pre_colored = Map.empty Temp.compare in
+        let manager, t0 = Temp.gen Temp.init_manager in
+        let manager, t1 = Temp.gen manager in
+        let manager, t2 = Temp.gen manager in
+        let _, t3 = Temp.gen manager in
+        (* ...             # live-out = [T0, T1]
+         * T0 := T0 + T1   # live-out = [T0, T1]
+         * Call (T2, T3)   # live-out = [T0, T1] 
+         * T0 := T0 + T1   # live-out = []
+         * ...
+         *
+         * (T0, T1) must be colored to callee_saved, 
+         * (T2, T3) should be able to utilize the extra callee_saved color *)
+        let instrs = Backend_aux.mk_annotated_vasms [t0; t1;]
+            [
+              (Vasm.mk_instr [t0; t1] [t0], [t0; t1;]);
+              (Vasm.mk_call  [t2; t3] [],   [t0; t1;]);
+              (Vasm.mk_instr [t0; t1] [t0], []);
+            ]
+        in
+        _check_coloring [(t0, 1); (t1, 0); (t2, 3); (t3, 2)]
+          (Reg_alloc.greedy_alloc instrs caller_saved callee_saved pre_colored);
+
+        (* [T0 ~ T3] := _ # live-out = [T0, T1, T2, T3] 
+         * Call           # live-out = [T0, T1, T2, T3] 
+         * [T0 ~ T3]      # live-out = []
+         *
+         * one of [T0 ~ T3] needs to be spilled *)
+        let instrs = Backend_aux.mk_annotated_vasms []
+            [
+              (Vasm.mk_instr [] [t0; t1; t2; t3], [t0; t1; t2; t3]);
+              (Vasm.mk_call  [] [],               [t0; t1; t2; t3]);
+              (Vasm.mk_instr [t0; t1; t2; t3] [], []);
+            ]
+        in
+        (* caller/callee saved shouldn't matter for these instrs *)
+        _check_spills [t0]
+          (Reg_alloc.greedy_alloc instrs caller_saved callee_saved pre_colored);
+      );
+
+    OUnit2.(>::) "test_greedy_alloc_with_precolor_has_call" (fun _ ->
+        let callee_saved = _int_set [0; 1] in
+        let caller_saved = _int_set [2] in
+        let manager, t0 = Temp.gen Temp.init_manager in
+        let _, t1 = Temp.gen manager in
+        let pre_colored = _temp_pairs_to_map [(t1, 2)] in
+        (*             # live-out = []
+         * T0, T1 := _ # live-out = [T0, T1]
+         * Call        # live-out = [T0, T1] 
+         * T0 + T1     # live-out = []
+         * ...
+         *
+         * - w/o pre-coloring, T0 and T1 will take up calle_saved colors,
+         * - with pre-coloring T1 to callee_saved, it must be spilled. *)
+        let instrs = Backend_aux.mk_annotated_vasms []
+            [
+              (Vasm.mk_instr [] [t0; t1], [t0; t1]);
+              (Vasm.mk_call  [] [],       [t0; t1]);
+              (Vasm.mk_instr [t0; t1] [], []);
+            ]
+        in
+        _check_coloring [(t0, 1); (t1, 0)]
+          (Reg_alloc.greedy_alloc
+             instrs caller_saved callee_saved _empty_temp_map);
+        _check_spills [t1]
+          (Reg_alloc.greedy_alloc
+             instrs caller_saved callee_saved pre_colored);
+      );
+  ]
+
+let _ =
+  OUnit2.run_test_tt_main tests

--- a/test/dune
+++ b/test/dune
@@ -10,6 +10,7 @@
 
    ; backend
    cir_test temp_test label_test graph_test vasm_test liveness_analysis_test
+   reg_alloc_test
 
    ; helper functions
    test_aux


### PR DESCRIPTION
This is non-trivial. I spent many hours
- designing the register allocator interface
- coming up with this greedy, scanning version of the graph-coloring algorithm
- debugging

I think the most interesting part is handling caller-callee saved registers. The latter is easier, we can scan the final assembly at the end, and insert spill/restore at prologue/epilogue. The former is weird, theoretically it's like "the caller-saved registers" are written to in any "call" instruction, but the register allocator's job is to figure out which temp maps to those physical registers! It's like a tail chasing scenario. What I did is to inform register allocator which regs are caller/callee-saved, and let it pre-color all temps that live across a call instruction to callee-saved regs (else it _must_ be spilled).

Anyway, I hope this is well documented and written with reasonable clarity.