### PR TITLE
Bridge X86 and register allocator

### DIFF
--- a/lib/backend/label.ml
+++ b/lib/backend/label.ml
@@ -19,14 +19,21 @@ let _add_suffix t (extra : string) : t =
   { t with suffix }
 ;;
 
+let _native_suffix = "native"
+;;
+
 (* NOTE this must synch with the assembly label of the externally defined
  * function. *)
 let get_native (name : string) =
-  { name; suffix = "$" } (* disjoint from other [t] *)
+  { name; suffix = _native_suffix } (* disjoint from other [t] *)
+;;
+
+let is_native t =
+  t.suffix = _native_suffix
 ;;
 
 let to_epilogue t =
-  let suffix = String.append t.suffix "$epilogue" in
+  let suffix = String.append t.suffix "_epilogue" in
   { t with suffix } (* disjoint from other [t] *)
 ;;
 
@@ -63,4 +70,8 @@ let gen_and_bind manager (s : string) : (manager * t) =
 
 let get manager s =
   Map.get s manager.name_cache
+;;
+
+let compare t1 t2 =
+  String.compare (to_string t1) (to_string t2)
 ;;

--- a/lib/backend/label.mli
+++ b/lib/backend/label.mli
@@ -27,7 +27,14 @@ val gen_and_bind : manager -> string -> (manager * t)
     It's guaranteed to be unique if [name] is unique *)
 val get_native : string -> t
 
+(** [to_epilogue t] returns a label that will start the epilogue portion of the
+   function represented by [t]. Guaranteed to be unique. *)
 val to_epilogue : t -> t
+
+(** [is_native t] returns true iff [t] is created via [get_native] *)
+val is_native : t -> bool
 
 (** [to_string t] returns a string representation of [t] *)
 val to_string : t -> string
+
+val compare : t -> t -> int

--- a/lib/backend/x86.ml
+++ b/lib/backend/x86.ml
@@ -578,3 +578,41 @@ let spill_temps temp_func temps_to_spill =
   let ctx = List.fold_left _spill_instr ctx temp_func.instrs in
   { temp_func with instrs = List.rev ctx.rev_instrs }
 ;;
+
+
+let _physical_reg_to_int (pr : physical_reg) : int =
+  match pr with
+  | Rax -> 0
+  | Rbx -> 1
+  | Rsi -> 2
+  | Rdi -> 3
+  | Rdx -> 4
+  | Rcx -> 5
+  | R8  -> 6
+  | R9  -> 7
+  | R10 -> 8
+  | R11 -> 9
+  | R12 -> 10
+  | R13 -> 11
+  | R14 -> 12
+  | R15 -> 13
+;;
+
+let _compare_physical_reg r1 r2 =
+  Int.compare (_physical_reg_to_int r1) (_physical_reg_to_int r2)
+;;
+
+let _physical_reg_list_to_set (prs : physical_reg list) : physical_reg Set.t =
+  List.fold_right Set.add prs (Set.empty _compare_physical_reg)
+;;
+
+let caller_saved_physical_regs =
+  _physical_reg_list_to_set [Rdi; Rsi; Rdx; Rcx; R8; R9; Rax; R11; R12]
+;;
+
+let callee_saved_physical_regs =
+  _physical_reg_list_to_set [Rbx; R12; R13; R14; R15]
+;;
+
+let rax_physical_reg = Rax
+;;

--- a/lib/backend/x86.mli
+++ b/lib/backend/x86.mli
@@ -96,6 +96,15 @@ val temp_func_to_vasms : temp_func -> Vasm.t list
     Final translation into [func] will set up the stack in prologue. *)
 val spill_temps : temp_func -> Temp.t Set.t -> temp_func
 
+(** [temp_func_to_func temp_func pr_assignment] returns a [func] with all
+    temps in [temp_func] replaced with X86 physical register based on
+    [pr_assignment].
+
+    Also generates prologue and epilogue of a function.
+
+    Error if any temp in [temp_func] is not in [pr_assignment]. *)
+val temp_func_to_func : temp_func -> (Temp.t, physical_reg) Map.t -> func
+
 
 (* Some pre-defined X86 physical registers *)
 val callee_saved_physical_regs     : physical_reg Set.t

--- a/lib/backend/x86.mli
+++ b/lib/backend/x86.mli
@@ -95,3 +95,10 @@ val temp_func_to_vasms : temp_func -> Vasm.t list
     NOTE stack is not set up, although stack slots are used.
     Final translation into [func] will set up the stack in prologue. *)
 val spill_temps : temp_func -> Temp.t Set.t -> temp_func
+
+
+(* Some pre-defined X86 physical registers *)
+val callee_saved_physical_regs     : physical_reg Set.t
+val caller_saved_physical_regs     : physical_reg Set.t
+val ordered_argument_physical_regs : physical_reg list
+val rax_physical_reg               : physical_reg

--- a/lib/backend/x86.mli
+++ b/lib/backend/x86.mli
@@ -40,9 +40,9 @@ type 'a instr =
       (* Load (arg, reg) --> reg := arg *)
   | Store of 'a arg * 'a reg * int
       (* Store (arg, reg, offset) --> *[reg + offset] := arg *)
-  | Push of 'a
-  | Pop of 'a
-  | Binop of binop * 'a * 'a arg
+  | Push of 'a reg
+  | Pop of 'a reg
+  | Binop of binop * 'a reg * 'a arg
       (* Binop (op, reg, arg) --> reg := op gr arg *)
   | Cmp of 'a arg * 'a
   | Jmp of Label.t

--- a/lib/backend/x86.mli
+++ b/lib/backend/x86.mli
@@ -43,7 +43,7 @@ type 'a instr =
   | Push of 'a
   | Pop of 'a
   | Binop of binop * 'a * 'a arg
-      (* Binop (op, gr, arg) --> gr := op gr arg *)
+      (* Binop (op, reg, arg) --> reg := op gr arg *)
   | Cmp of 'a arg * 'a
   | Jmp of Label.t
   | JmpC of cond * Label.t
@@ -90,3 +90,8 @@ val from_lir_prog : Lir.prog -> temp_prog
 
 (** Includes entry label in output vasms. *)
 val temp_func_to_vasms : temp_func -> Vasm.t list
+
+(** Guaranteed to spill onto slots aligned by word size.
+    NOTE stack is not set up, although stack slots are used.
+    Final translation into [func] will set up the stack in prologue. *)
+val spill_temps : temp_func -> Temp.t Set.t -> temp_func

--- a/lib/stdlib/int.ml
+++ b/lib/stdlib/int.ml
@@ -7,6 +7,10 @@ let max x y =
   if x > y then x else y
 ;;
 
+let ceil_div n1 n2 =
+  (n1 + n2 - 1) / n2
+;;
+
 let compare n1 n2 =
   if n1 = n2 then 0
   else if n1 > n2 then 1

--- a/lib/stdlib/int.mli
+++ b/lib/stdlib/int.mli
@@ -6,6 +6,9 @@ val max : int -> int -> int
 (** [min n1 n2] returns the smaller of [n1] and [n2] *)
 val min : int -> int -> int
 
+(** [ceil_div n1 n2] returns [n1 / n2] and rounds up the answer *)
+val ceil_div : int -> int -> int
+
 (** [compare n1 n2] returns
     - negative if [n1 > n2]
     - 0        if [n1 = n2]

--- a/test/backend/label_test.ml
+++ b/test/backend/label_test.ml
@@ -28,6 +28,18 @@ let tests = OUnit2.(>:::) "label_test" [
         OUnit2.assert_equal false ((Label.to_string foo_t) = (Label.to_string bar_t));
       );
 
+    OUnit2.(>::) "test_is_native" (fun _ ->
+        let manager = Label.init_manager in
+        let manager, t1 = Label.gen manager "s1" in
+        let _, t2 = Label.gen_and_bind manager "s1" in
+        let t2_epi = Label.to_epilogue t2 in
+        let foo_t = Label.get_native "foo" in
+        OUnit2.assert_equal false (Label.is_native t1);
+        OUnit2.assert_equal false (Label.is_native t2);
+        OUnit2.assert_equal true (Label.is_native foo_t);
+        OUnit2.assert_equal false (Label.is_native t2_epi);
+      );
+
     OUnit2.(>::) "test_to_epilogue" (fun _ ->
         let manager = Label.init_manager in
         let manager, t1 = Label.gen manager "s1" in

--- a/test/stdlib/int_test.ml
+++ b/test/stdlib/int_test.ml
@@ -13,6 +13,14 @@ let tests = OUnit2.(>:::) "int_test" [
         OUnit2.assert_equal ~-4 (Int.min ~-2 ~-4);
       );
 
+    OUnit2.(>::) "test_ceil_div" (fun _ ->
+        OUnit2.assert_equal 2 (Int.ceil_div 6 5);
+        OUnit2.assert_equal 1 (Int.ceil_div 5 5);
+        OUnit2.assert_equal 1 (Int.ceil_div 4 5);
+        OUnit2.assert_equal 1 (Int.ceil_div 1 5);
+        OUnit2.assert_equal 0 (Int.ceil_div 0 5);
+      );
+
     OUnit2.(>::) "test_compare" (fun _ ->
         OUnit2.assert_equal true ((Int.compare 5 5) = 0);
         OUnit2.assert_equal true ((Int.compare 3 7) < 0);


### PR DESCRIPTION
Add functions in X86 to spill or map Temp register to X86 physical register, so we can use the output of register allocator to generate final X86 assembly with physical registers, prologue and epilogue.