### PR TITLE
X86 to string

### DIFF
--- a/lib/backend/lir.ml
+++ b/lib/backend/lir.ml
@@ -39,6 +39,7 @@ type prog =
   { funcs : func list
   ; entry : instr list
   ; temp_manager  : Temp.manager
+  ; label_manager : Label.manager
   }
 
 
@@ -117,7 +118,7 @@ let _ctx_gen_and_bind_temp (ctx : context) (ident : string)
 
 
 
-(* Some constants *)
+(* Some constants. TODO bug, need to tag it, as if it's integer. *)
 let _true_e    = Imm 1
 and _false_e   = Imm 0
 ;;
@@ -458,5 +459,7 @@ let from_cir_prog (cir_prog : Cir.prog) =
   let ctx = _transl_cir_expr_tailpos ctx cir_prog.expr in
   { funcs
   ; entry = _ctx_get_instrs ctx
-  ; temp_manager = ctx.temp_manager }
+  ; temp_manager = ctx.temp_manager
+  ; label_manager = ctx.label_manager
+  }
 ;;

--- a/lib/backend/lir.mli
+++ b/lib/backend/lir.mli
@@ -57,6 +57,7 @@ type prog =
   { funcs         : func list
   ; entry         : instr list   (* no entry label, to be generated later *)
   ; temp_manager  : Temp.manager (* for [entry] *)
+  ; label_manager : Label.manager
   }
 
 

--- a/lib/backend/x86.ml
+++ b/lib/backend/x86.ml
@@ -809,7 +809,7 @@ let _binop_to_str (binop : binop) : string =
   match binop with
   | Add -> "add"
   | Sub -> "sub"
-  | Mul -> "mul"
+  | Mul -> "imul" (* 'i' for signed integer multiplication *)
 ;;
 
 let _instr_to_str (instr : 'a instr) (gr_to_str : 'a -> string) : string =

--- a/lib/backend/x86.mli
+++ b/lib/backend/x86.mli
@@ -50,8 +50,6 @@ type 'a instr =
       (* Jump to label if [cond] is satisfied. *)
   | Call_reg of 'a
   | Call_lbl of Label.t
-  | SetC of cond * 'a
-      (* Sets content of ['a] to 1 if [cond] is satisfied, else 0 *)
   | Ret
       (* Return control flow to caller site *)
 

--- a/lib/backend/x86.mli
+++ b/lib/backend/x86.mli
@@ -38,8 +38,8 @@ type 'a instr =
   | Label of Label.t
   | Load of 'a arg * 'a reg
       (* Load (arg, reg) --> reg := arg *)
-  | Store of 'a arg * 'a reg * int
-      (* Store (arg, reg, offset) --> *[reg + offset] := arg *)
+  | Store of 'a reg * 'a reg * int
+      (* Store (sreg, dreg, offset) --> *[dreg + offset] := sreg *)
   | Push of 'a reg
   | Pop of 'a reg
   | Binop of binop * 'a reg * 'a arg

--- a/lib/backend/x86.mli
+++ b/lib/backend/x86.mli
@@ -105,6 +105,9 @@ val spill_temps : temp_func -> Temp.t Set.t -> temp_func
     Error if any temp in [temp_func] is not in [pr_assignment]. *)
 val temp_func_to_func : temp_func -> (Temp.t, physical_reg) Map.t -> func
 
+(** [prog_to_str prog] outputs a valid X86 assembly text of [prog] *)
+val prog_to_str : prog -> string
+
 
 (* Some pre-defined X86 physical registers *)
 val callee_saved_physical_regs     : physical_reg Set.t


### PR DESCRIPTION
Implement translation from X86 program with physical register to final assembly code.
Discovered some neglected requirements from X86 assembly, and fixed X86 accordingly.

Notably, `setCC` requires byte access to target register. Ideally we should wrap the general purpose registers in X86 with `[B1, B2, B4, B8]` to implement that, but since (1) currently there is no other use case, (2) it's hard to enforce access requirements of different instructions (I'm too lazy to look into this), we'll use the compare-set-jump approach to translate conditional set from Lir.