### PR TITLE
Compiler integration

### DIFF
--- a/bin/soc.ml
+++ b/bin/soc.ml
@@ -2,6 +2,13 @@ open Pervasives
 
 let () =
   let filename = Sys.argv.(1) in
-  match Driver.type_file filename with
-  | Ok ast -> Io.println (Pretty.pp_ast_structure ast)
+  match Driver.lir_file filename with
+  | Ok lir_prog ->
+    let x86_prog = Driver.lir_to_x86 lir_prog in
+    let x86_prog_str = X86.prog_to_str x86_prog in
+    let extless_filename, _ = Filename.split_extension filename in
+    let output_filename = String.append extless_filename ".s" in
+    Io.write_file output_filename x86_prog_str
+
   | Error msg -> Io.println msg
+;;

--- a/lib/driver.mli
+++ b/lib/driver.mli
@@ -11,3 +11,6 @@ val parse_file : string -> (Ast.structure, string) result
 val type_file  : string -> (Ast.structure, string) result
 val cir_file  : string -> (Cir.prog, string) result
 val lir_file  : string -> (Lir.prog, string) result
+
+(** Wire up instruction selection and register allocation *)
+val lir_to_x86 : Lir.prog -> X86.prog

--- a/lib/stdlib/externals.ml
+++ b/lib/stdlib/externals.ml
@@ -23,6 +23,12 @@ let read_entire_file (filename : string) : string =
   s
 ;;
 
+let write_entire_file (filename : string) (content : string) : unit =
+  let oc = open_out filename in
+  output_string oc content;
+  close_out oc;
+;;
+
 let print s =
   Stdlib.print_string s;
   Stdlib.flush Stdlib.stdout

--- a/lib/stdlib/filename.ml
+++ b/lib/stdlib/filename.ml
@@ -1,0 +1,23 @@
+open Pervasives
+
+(* ASSUME [n < String.length s]
+ * Excludes [String.get s n], return the substring before and after it. *)
+let _split_at (s : string) (n : int) =
+  let s_length = String.length s in
+  let before_n = String.sub s 0 n in
+  let after_n  = String.sub s (n + 1) (s_length - n - 1) in
+  (before_n, after_n)
+;;
+
+let split_extension s =
+  let rec go n = (* ASSUME n < [s_length] *)
+    if n < 0 then (s, None)
+    else
+      match String.get s n with
+      | '.' ->
+        let before_dot, after_dot = _split_at s n in
+        (before_dot, Some after_dot)
+      | _ -> go (n - 1)
+  in
+  go ((String.length s) - 1)
+;;

--- a/lib/stdlib/filename.mli
+++ b/lib/stdlib/filename.mli
@@ -1,0 +1,7 @@
+open Pervasives
+
+(** [split_extension s] splits [s] by the last ".", and return the substring
+    before and after the ".".
+    If no "." is found, return [None] for the second substring. *)
+val split_extension : string -> string * string option
+

--- a/lib/stdlib/io.ml
+++ b/lib/stdlib/io.ml
@@ -2,6 +2,9 @@
 let read_file = Externals.read_entire_file
 ;;
 
+let write_file = Externals.write_entire_file
+;;
+
 let println s =
   Externals.print s;
   Externals.print "\n"

--- a/lib/stdlib/io.mli
+++ b/lib/stdlib/io.mli
@@ -4,5 +4,9 @@
     errors on any IO issue *)
 val read_file : string -> string
 
+(** [write_file path content] creates or overwrites a file at [path] so that
+    it contains [content]; errors on any IO issue *)
+val write_file : string -> string -> unit
+
 (** [println s] prints [s] and a newline to stdout *)
 val println : string -> unit

--- a/test/dune
+++ b/test/dune
@@ -2,7 +2,7 @@
   (names
    ; stdlib
    list_test option_test set_test map_test int_test char_test string_test
-   result_test
+   result_test filename_test
 
    ; frontend
    location_test span_test lexer_test parser_test ast_interp_test typer_test

--- a/test/stdlib/filename_test.ml
+++ b/test/stdlib/filename_test.ml
@@ -1,0 +1,25 @@
+open Pervasives
+
+let tests = OUnit2.(>:::) "filename_test" [
+
+    OUnit2.(>::) "test_split_extension" (fun _ ->
+        OUnit2.assert_equal 
+          ("", None)
+          (Filename.split_extension "");
+        OUnit2.assert_equal 
+          ("abc", None)
+          (Filename.split_extension "abc");
+        OUnit2.assert_equal 
+          ("", Some "")
+          (Filename.split_extension ".");
+        OUnit2.assert_equal 
+          ("a.", Some "")
+          (Filename.split_extension "a..");
+        OUnit2.assert_equal 
+          ("a.b", Some "cde")
+          (Filename.split_extension "a.b.cde");
+      );
+  ]
+
+let _ =
+  OUnit2.run_test_tt_main tests


### PR DESCRIPTION
Link all parts of the compiler together. 
Essentially, we can use `ocamlc` to obtain a `soc` executable, which can map soml source code to x86 assembly.