### PR TITLE
Make debugging easier with better printing functions

### DIFF
--- a/lib/backend/graph.ml
+++ b/lib/backend/graph.ml
@@ -27,8 +27,7 @@ let empty_graph () =
 let _get_node_info (t : 'a t) (n : node) (func : string) : 'a node_info =
   match Map.get n t.node_infos with
   | None ->
-    failwith 
-      (String.join_with ["[Graph."; func; "] node not bound in graph"] "")
+    failwith (String.concat ["[Graph."; func; "] node not bound in graph"])
   | Some info -> info
 ;;
 

--- a/lib/backend/reg_alloc.ml
+++ b/lib/backend/reg_alloc.ml
@@ -91,9 +91,9 @@ let _ctx_remove_dead_temps (ctx : 'a context) (killed : Temp.t Set.t)
            if Set.mem killed_temp ctx.temps_to_spill then avalb_colors
            else
              failwith 
-               (String.join_with
+               (String.concat
                   ["[Reg_alloc._ctx_remove_killed_temps] Unspilled killed Temp "
-                  ; (Temp.to_string killed_temp); " should've been colored";] "")
+                  ; (Temp.to_string killed_temp); " should've been colored";])
          | Some color ->
            Set.add color avalb_colors)
       ctx.avalb_colors (Set.to_list killed)

--- a/lib/backend/vasm.ml
+++ b/lib/backend/vasm.ml
@@ -318,7 +318,7 @@ let _pp_jump (jump : jump) : string =
     | Conditional -> "conditional"
     | Unconditional -> "unconditional"
   in
-  String.join_with [kind_str; " jump to "; Label.to_string jump.target] ""
+  String.concat [kind_str; " jump to "; Label.to_string jump.target]
 ;;
 
 let _pp_instr (instr : instr) : string =
@@ -330,9 +330,9 @@ let _pp_instr (instr : instr) : string =
     | Jump jump -> _pp_jump jump
   in
   let rw_str =
-    String.join_with
+    String.concat
       [", reads = "; Set.to_string Temp.to_string instr.reads;
-       ", writes = "; Set.to_string Temp.to_string instr.writes;] ""
+       ", writes = "; Set.to_string Temp.to_string instr.writes;]
   in
   String.append desc_str rw_str
 ;;

--- a/lib/backend/x86.ml
+++ b/lib/backend/x86.ml
@@ -893,7 +893,7 @@ let _reg_offset_to_str
     else " + ", offset
   in
   let offset_str = Int.to_string offset in
-  String.join_with ["["; reg_str; op_str; offset_str ; "]"] ""
+  String.concat ["["; reg_str; op_str; offset_str ; "]"]
 ;;
 
 let _arg_to_str (arg : 'a arg) (gr_to_str : 'a -> string) : string =
@@ -932,37 +932,36 @@ let _instr_to_str (instr : 'a instr) (gr_to_str : 'a -> string) : string =
   | Load (arg, dst_reg) ->
     let arg_str = _arg_to_str arg gr_to_str in
     let dst_str = _reg_to_str dst_reg gr_to_str in
-    let instr_str = String.join_with ["mov "; dst_str; ", "; arg_str;] "" in
+    let instr_str = String.concat ["mov "; dst_str; ", "; arg_str;] in
     add_tab instr_str
 
   | Store (src_reg, dst_addr_reg, offset) ->
     let src_str = _reg_to_str src_reg gr_to_str in
     let dst_str = _reg_offset_to_str dst_addr_reg offset gr_to_str in
-    let instr_str = String.join_with ["mov "; dst_str; ", "; src_str;] "" in
+    let instr_str = String.concat ["mov "; dst_str; ", "; src_str;] in
     add_tab instr_str
 
   | Push reg ->
     let reg_str = _reg_to_str reg gr_to_str in
-    let instr_str = String.join_with ["push"; reg_str] " " in
+    let instr_str = String.concat ["push"; " "; reg_str] in
     add_tab instr_str
 
   | Pop reg ->
     let reg_str = _reg_to_str reg gr_to_str in
-    let instr_str = String.join_with ["pop"; reg_str] " " in
+    let instr_str = String.concat ["pop"; " "; reg_str] in
     add_tab instr_str
 
   | Binop (binop, reg, arg) ->
     let arg_str = _arg_to_str arg gr_to_str in
     let reg_str = _reg_to_str reg gr_to_str in
     let binop_str = _binop_to_str binop in
-    let instr_str =
-      String.join_with [binop_str; " "; reg_str; ", "; arg_str;] "" in
+    let instr_str = String.concat [binop_str; " "; reg_str; ", "; arg_str;] in
     add_tab instr_str
 
   | Cmp (arg, pr) ->
     let arg_str = _arg_to_str arg gr_to_str in
-    let pr_str = _physical_reg_to_str pr in
-    let instr_str = String.join_with ["cmp "; arg_str; ", "; pr_str;] "" in
+    let pr_str = physical_reg_to_str pr in
+    let instr_str = String.concat ["cmp "; arg_str; ", "; pr_str;] in
     add_tab instr_str
 
   | Jmp label ->
@@ -972,12 +971,12 @@ let _instr_to_str (instr : 'a instr) (gr_to_str : 'a -> string) : string =
   | JmpC (cond, label) ->
     let suffix = _cond_to_suffix cond in
     let label_str = Label.to_string label in
-    let instr_str = String.join_with ["j"; suffix; " "; label_str] "" in
+    let instr_str = String.concat ["j"; suffix; " "; label_str] in
     add_tab instr_str
 
   | Call (target, _) -> (* args are used for liveness analysis or debugging *)
     let target_str = _call_target_to_str target gr_to_str in
-    let instr_str = String.join_with ["call"; " "; target_str] "" in
+    let instr_str = String.concat ["call"; " "; target_str] in
     add_tab instr_str
 
   | Ret -> add_tab "ret"

--- a/lib/backend/x86.ml
+++ b/lib/backend/x86.ml
@@ -958,10 +958,10 @@ let _instr_to_str (instr : 'a instr) (gr_to_str : 'a -> string) : string =
     let instr_str = String.concat [binop_str; " "; reg_str; ", "; arg_str;] in
     add_tab instr_str
 
-  | Cmp (arg, pr) ->
+  | Cmp (arg, gr) ->
     let arg_str = _arg_to_str arg gr_to_str in
-    let pr_str = physical_reg_to_str pr in
-    let instr_str = String.concat ["cmp "; arg_str; ", "; pr_str;] in
+    let gr_str = gr_to_str gr in
+    let instr_str = String.concat ["cmp "; arg_str; ", "; gr_str;] in
     add_tab instr_str
 
   | Jmp label ->
@@ -1068,4 +1068,9 @@ let prog_to_str (prog : prog) : string =
   let func_strs = List.map _func_to_str all_funcs in
   let funcs_str = String.join_with func_strs "\n\n" in
   String.join_with [metadata_str; funcs_str] "\n\n"
+;;
+
+let temp_func_to_str temp_func =
+  let all_instrs = (Label temp_func.entry)::temp_func.instrs in
+  _instrs_to_str all_instrs Temp.to_string
 ;;

--- a/lib/backend/x86.ml
+++ b/lib/backend/x86.ml
@@ -857,7 +857,7 @@ let temp_func_to_func temp_func pr_assignment =
 ;;
 
 
-let _physical_reg_to_str (r : physical_reg) : string =
+let physical_reg_to_str (r : physical_reg) : string =
   match r with
   | Rax -> "RAX"
   | Rbx -> "RBX"
@@ -991,7 +991,7 @@ let _instrs_to_str (instrs : 'a instr list) (gr_to_str : 'a -> string)
 
 let _func_to_str (func : func) : string =
   let all_instrs = (Label func.entry)::func.instrs in
-  _instrs_to_str all_instrs _physical_reg_to_str
+  _instrs_to_str all_instrs physical_reg_to_str
 ;;
 
 

--- a/lib/backend/x86.mli
+++ b/lib/backend/x86.mli
@@ -112,6 +112,7 @@ val temp_func_to_func : temp_func -> (Temp.t, physical_reg) Map.t -> func
 (** [prog_to_str prog] outputs a valid X86 assembly text of [prog] *)
 val prog_to_str : prog -> string
 
+val physical_reg_to_str : physical_reg -> string
 
 (* Some pre-defined X86 physical registers *)
 val callee_saved_physical_regs     : physical_reg Set.t

--- a/lib/backend/x86.mli
+++ b/lib/backend/x86.mli
@@ -112,6 +112,8 @@ val temp_func_to_func : temp_func -> (Temp.t, physical_reg) Map.t -> func
 (** [prog_to_str prog] outputs a valid X86 assembly text of [prog] *)
 val prog_to_str : prog -> string
 
+(* For debugging *)
+val temp_func_to_str : temp_func -> string
 val physical_reg_to_str : physical_reg -> string
 
 (* Some pre-defined X86 physical registers *)

--- a/lib/common/pretty.ml
+++ b/lib/common/pretty.ml
@@ -635,3 +635,12 @@ let pp_lir_prog prog =
   _pp_lir_prog p prog;
   p.buffer
 ;;
+
+
+let pp_vasm_liveness_annot vasm_annot_pairs =
+  List.to_string vasm_annot_pairs
+    (fun (vasm, (annot : Liveness_analysis.annot)) -> 
+       let vasm_str = Vasm.pp vasm in
+       let annot_str = Set.to_string Temp.to_string annot.live_out in
+       String.join_with [vasm_str; annot_str] " # ")
+;;

--- a/lib/common/pretty.ml
+++ b/lib/common/pretty.ml
@@ -64,29 +64,27 @@ let _print_newline (p : printer) : unit =
 let pp_lexer_error (err : Errors.lexer_error) : string =
   match err with
   | Lexer_unexpected_char (expect, actual, loc) ->
-    String.join_with
+    String.concat
       [ "[Lexer] Expected '"; (Char.to_string expect);
         "', but got '"; (Char.to_string actual); "'";
         " at "; (Location.to_string loc); ]
-      ""
+
   | Lexer_unexpected_eof (where, expected) ->
-    String.join_with
+    String.concat
       [ "[Lexer] Unexpected EOF while expecting "; (Char.to_string expected);
         " at "; (Location.to_string where); ]
-      ""
+
   | Lexer_invalid_start (start, loc) ->
-    String.join_with
+    String.concat
       [ "[Lexer] Invalid start of token: '"; (Char.to_string start);
         "' at "; (Location.to_string loc); ]
-      ""
 ;;
 
 
 let _pp_span (span : Span.t) : string =
-  String.join_with
+  String.concat
     [ "<"; (Location.to_string span.start); "-";
       (Location.to_string span.final); ">" ]
-    ""
 ;;
 
 (* Whether to show content of [Token.Int], etc. *)
@@ -97,8 +95,8 @@ type token_desc_visibility =
 let _pp_token_desc_impl desc (visibility : token_desc_visibility) =
   let pp_tok_with_content (tok : string) (content : string) =
     match visibility with
-    | Hide_content -> String.join_with ["<"; tok; ">"] ""
-    | Show_content -> String.join_with ["<"; tok; " ("; content; ")>"] ""
+    | Hide_content -> String.concat ["<"; tok; ">"]
+    | Show_content -> String.concat ["<"; tok; " ("; content; ")>"]
   in
   match desc with
   | Token.AmperAmper -> "<AmperAmper>"
@@ -134,10 +132,9 @@ let pp_token_desc desc =
 ;;
 
 let pp_token (tok : Token.t) =
-  String.join_with
+  String.concat
     [ "{"; (pp_token_desc tok.token_desc);
       " at "; (_pp_span tok.token_span); "}"; ]
-    ""
 ;;
 
 let pp_parser_error (err : Errors.parser_error) =
@@ -148,37 +145,36 @@ let pp_parser_error (err : Errors.parser_error) =
   in
   match err with
   | Parser_invalid_integer (text, span) ->
-    String.join_with
+    String.concat
       [ "[Parser]: Invalid integer token <"; text; "> at "; (_pp_span span); ]
-      ""
+
   | Parser_unexpected_token (actual, expects) ->
-    String.join_with
+    String.concat
       [ "[Parser]: Unexpected token "; (pp_token actual);
         " where expected tokens are "; (pp_expected_tokens expects); ]
-      ""
+
   | Parser_unexpected_eof (eof_loc, expects) ->
-    String.join_with
+    String.concat
       [ "[Parser]: Unexpected EOF at "; (Location.to_string eof_loc);
         " where expected tokens are "; (pp_expected_tokens expects); ]
-      ""
 ;;
 
 let pp_ast_interp_error (err : Errors.ast_interp_error) =
   match err with
   | Ast_interp_unbound_var (name, span) ->
-    String.join_with
+    String.concat
       [ "[Ast_interp]: Unbound variable <"; name; "> at "; (_pp_span span); ]
-      ""
+
   | Ast_interp_type_mismatch (expect, actual, span) ->
-    String.join_with
+    String.concat
       [ "[Ast_interp]: Expected type <"; expect; ">";
         " but got <"; actual; "> at "; (_pp_span span); ]
-      ""
+
   | Ast_interp_arity_mismatch (expect, actual, span) ->
-    String.join_with
+    String.concat
       [ "[Ast_interp]: Expected arity "; (Int.to_string expect);
         " but got "; (Int.to_string actual); " at "; (_pp_span span); ]
-      ""
+
   | Ast_interp_letrec_invalid_rhs span ->
     String.append "Invalid rhs of let rec binding at " (_pp_span span)
 ;;
@@ -359,23 +355,24 @@ let pp_ast_expr_with_typ_annot (expr : Ast.expression) =
 let pp_typer_error (err : Errors.typer_error) =
   match err with
   | Typer_unbound_var (name, span) ->
-    String.join_with
+    String.concat
       [ "[Typer]: Unbound variable <"; name; "> at "; (_pp_span span); ]
-      ""
+
   | Typer_type_mismatch (expect, actual, span) ->
-    String.join_with
+    String.concat
       [ "[Typer]: Expected type <"; (pp_ast_typ expect); ">";
         " but got <"; (pp_ast_typ actual); "> at "; (_pp_span span); ]
-      ""
+
   | Typer_illegal_letrec_rhs span ->
     String.append "[Typer]: Illegal rhs of let rec binding at " (_pp_span span)
+
   | Typer_tyvar_occurs (expect, actual, actual_span, tv_name, occurree) ->
-    String.join_with
+    String.concat
       [ "[Typer]: Expected type <"; (pp_ast_typ expect); ">";
         " but got <"; (pp_ast_typ actual); "> at "; (_pp_span actual_span);
         ". The type variable '"; tv_name;
         " occurs within "; (pp_ast_typ occurree) ]
-      ""
+
 ;;
 
 

--- a/lib/common/pretty.ml
+++ b/lib/common/pretty.ml
@@ -144,11 +144,7 @@ let pp_parser_error (err : Errors.parser_error) =
   let pp_expected_tokens (toks : Token.desc list) : string =
     match toks with
     | [] -> "<unknown>"
-    | _ ->
-      let tok_strs =
-        List.map (fun tok -> _pp_token_desc_impl tok Hide_content) toks in
-      let inner = String.join_with tok_strs "; " in
-      String.join_with ["["; inner; "]"] ""
+    | _ -> List.to_string toks (fun tok -> _pp_token_desc_impl tok Hide_content)
   in
   match err with
   | Parser_invalid_integer (text, span) ->

--- a/lib/common/pretty.mli
+++ b/lib/common/pretty.mli
@@ -1,3 +1,4 @@
+open Pervasives
 
 (* functions to format datatypes from various parts of the compiler *)
 
@@ -19,3 +20,4 @@ val pp_typer_error      : Errors.typer_error -> string
 (* Backend stuff *)
 val pp_cir : Cir.prog -> string
 val pp_lir_prog : Lir.prog -> string
+val pp_vasm_liveness_annot : (Vasm.t * Liveness_analysis.annot) list -> string

--- a/lib/frontend/location.ml
+++ b/lib/frontend/location.ml
@@ -10,9 +10,8 @@ let create row col =
 ;;
 
 let to_string t =
-  String.join_with
-    ["("; (Int.to_string t.row); ", "; (Int.to_string t.col); ")"]
-    ""
+  let row_str, col_str = Int.to_string t.row, Int.to_string t.col in
+  String.concat ["("; row_str; ", "; col_str; ")"]
 ;;
 
 let advance t =

--- a/lib/stdlib/list.ml
+++ b/lib/stdlib/list.ml
@@ -156,5 +156,5 @@ let init size f =
 let to_string xs f =
   let elem_strs = map f xs in
   let elems_str = String.join_with elem_strs "; " in
-  String.join_with ["["; elems_str; "]"] ""
+  String.concat ["["; elems_str; "]"]
 ;;

--- a/lib/stdlib/list.ml
+++ b/lib/stdlib/list.ml
@@ -152,3 +152,9 @@ let init size f =
   in
   go 0
 ;;
+
+let to_string xs f =
+  let elem_strs = map f xs in
+  let elems_str = String.join_with elem_strs "; " in
+  String.join_with ["["; elems_str; "]"] ""
+;;

--- a/lib/stdlib/list.mli
+++ b/lib/stdlib/list.mli
@@ -79,3 +79,7 @@ val combine : 'a list -> 'b list -> ('a * 'b) list
 
 (** [init len f] is [f 0; f 1; ...; f (len-1)], evaluated left to right. *)
 val init : int -> (int -> 'a) -> 'a list
+
+(** [to_string xs f] returns a string representation of [xs], using [f] to
+    format individual elemeents. *)
+val to_string : 'a list -> ('a -> string) -> string

--- a/lib/stdlib/map.ml
+++ b/lib/stdlib/map.ml
@@ -78,7 +78,7 @@ let foldi f t acc =
 
 let to_string f g t =
   let pair_to_str (k, v) =
-    String.join_with ["("; (f k); ", "; (g v); ")"] ""
+    String.concat ["("; (f k); ", "; (g v); ")"]
   in
   let pairs = List.map pair_to_str (_unique_pairs t) in
   let inner = String.join_with pairs "; " in

--- a/lib/stdlib/string.ml
+++ b/lib/stdlib/string.ml
@@ -38,3 +38,7 @@ let join_with init_ss sep =
         go acc ss
     in go fst_s rst_ss
 ;;
+
+let concat ss =
+  join_with ss ""
+;;

--- a/lib/stdlib/string.ml
+++ b/lib/stdlib/string.ml
@@ -26,12 +26,15 @@ let compare s1 s2 =
   go 0
 ;;
 
-let join_with ss sep =
-  match ss with
+let join_with init_ss sep =
+  match init_ss with
   | [] -> ""
-  | s::ss ->
-  List.fold_left
-    (fun acc s -> append (append acc sep) s)
-    s
-    ss
+  | fst_s::rst_ss ->
+    let rec go acc ss =
+      match ss with
+      | [] -> acc
+      | s::ss ->
+        let acc = append (append acc sep) s in
+        go acc ss
+    in go fst_s rst_ss
 ;;

--- a/lib/stdlib/string.mli
+++ b/lib/stdlib/string.mli
@@ -19,3 +19,6 @@ val compare : string -> string -> int
 (** [join_with [s1; ...; sn] sep] is [s1 ^ sep ^ ... ^ sep ^ sn] where [^]
     stands for the append operation *)
 val join_with : string list -> string -> string
+
+(** [concat ss] = [join_with ss ""] *)
+val concat : string list -> string

--- a/test/soc/backend/liveness_analysis_test.ml
+++ b/test/soc/backend/liveness_analysis_test.ml
@@ -1,15 +1,5 @@
 open Pervasives
 
-let _annotated_vasms_to_str
-    (avs : (Vasm.t * Liveness_analysis.annot) list)
-  : string =
-  List.to_string avs
-    (fun (vasm, annot) -> 
-       let vasm_str = Vasm.pp vasm in
-       let annot_str = Set.to_string Temp.to_string annot.live_out in
-       String.join_with [vasm_str; annot_str] " # ")
-;;
-
 let _annotated_vasm_equal
   ((v1 : Vasm.t), (a1 : Liveness_analysis.annot))
   ((v2 : Vasm.t), (a2 : Liveness_analysis.annot))
@@ -62,7 +52,7 @@ let tests = OUnit2.(>:::) "Liveness_analysis_test" [
         let vasms = List.map (fun (instr, _) -> instr) expected in
         let annotated_vasms = Liveness_analysis.analyze_vasm vasms in
         OUnit2.assert_equal
-          ~printer:_annotated_vasms_to_str
+          ~printer:Pretty.pp_vasm_liveness_annot
           ~cmp:(Test_aux.list_equal _annotated_vasm_equal)
           expected annotated_vasms
       );
@@ -132,7 +122,7 @@ let tests = OUnit2.(>:::) "Liveness_analysis_test" [
         let vasms = List.map (fun (instr, _) -> instr) expected in
         let annotated_vasms = Liveness_analysis.analyze_vasm vasms in
         OUnit2.assert_equal
-          ~printer:_annotated_vasms_to_str
+          ~printer:Pretty.pp_vasm_liveness_annot
           ~cmp:(Test_aux.list_equal _annotated_vasm_equal)
           expected annotated_vasms
       );

--- a/test/soc/backend/liveness_analysis_test.ml
+++ b/test/soc/backend/liveness_analysis_test.ml
@@ -1,19 +1,13 @@
 open Pervasives
 
-let _annotated_vasm_to_str
-    ((vasm : Vasm.t), (annot : Liveness_analysis.annot))
-  : string =
-  let vasm_str = Vasm.pp vasm in
-  let annot_str = Set.to_string Temp.to_string annot.live_out in
-  String.join_with [vasm_str; annot_str] " # "
-;;
-
 let _annotated_vasms_to_str
     (avs : (Vasm.t * Liveness_analysis.annot) list)
   : string =
-  let av_strs = List.map _annotated_vasm_to_str avs in
-  let avs_str = String.join_with av_strs ";\n" in
-  String.join_with ["["; avs_str; "]"] ""
+  List.to_string avs
+    (fun (vasm, annot) -> 
+       let vasm_str = Vasm.pp vasm in
+       let annot_str = Set.to_string Temp.to_string annot.live_out in
+       String.join_with [vasm_str; annot_str] " # ")
 ;;
 
 let _annotated_vasm_equal

--- a/test/soc/backend/reg_alloc_test.ml
+++ b/test/soc/backend/reg_alloc_test.ml
@@ -43,8 +43,7 @@ let _check_spills
       String.join_with (List.map Temp.to_string expect_spills) ", " in
     let actual_str = Set.to_string Temp.to_string spills in
     let error_msg =
-      String.join_with
-        ["expected: ["; expect_str; "]; actual: "; actual_str] ""
+      String.concat ["expected: ["; expect_str; "]; actual: "; actual_str]
     in
     OUnit2.assert_bool error_msg (same_length && is_subset);
   | Ok coloring -> _err_unexpected_coloring coloring
@@ -68,15 +67,14 @@ let _check_coloring
     let pair_strs =
       List.map
         (fun (temp, color) ->
-           String.join_with
-             ["("; Temp.to_string temp; ", "; Int.to_string color; ")"] "")
+           String.concat
+             ["("; Temp.to_string temp; ", "; Int.to_string color; ")"])
         expected_coloring
     in
     let expect_str = String.join_with pair_strs ", " in
     let actual_str = Map.to_string Temp.to_string Int.to_string coloring in
     let error_msg =
-      String.join_with
-        ["expected: ["; expect_str; "]; actual: "; actual_str] ""
+      String.concat ["expected: ["; expect_str; "]; actual: "; actual_str]
     in
     OUnit2.assert_bool error_msg (same_length && is_subset);
 ;;

--- a/test/soc/stdlib/list_test.ml
+++ b/test/soc/stdlib/list_test.ml
@@ -155,6 +155,13 @@ let tests = OUnit2.(>:::) "list_tests" [
         OUnit2.assert_equal [] (List.init 0 Int.to_string);
         OUnit2.assert_equal ["0"; "1"; "2"] (List.init 3 Int.to_string);
       );
+
+    OUnit2.(>::) "test_to_string" (fun _ ->
+        OUnit2.assert_equal "[]" (List.to_string [] (fun _ -> "1"));
+        OUnit2.assert_equal
+          "[1; 2; 3]"
+          (List.to_string [1; 2; 3] Int.to_string);
+      );
   ]
 
 let _ =

--- a/test/soc/stdlib/string_test.ml
+++ b/test/soc/stdlib/string_test.ml
@@ -39,6 +39,11 @@ let tests = OUnit2.(>:::) "string_test" [
         OUnit2.assert_equal "ss" (String.join_with ["ss"] "aaa");
         OUnit2.assert_equal "a; bb; a" (String.join_with ["a"; "bb"; "a"] "; ");
       );
+
+    OUnit2.(>::) "test_concat" (fun _ ->
+        OUnit2.assert_equal "" (String.concat []);
+        OUnit2.assert_equal "a cc" (String.concat ["a"; " "; "cc"]);
+      );
   ]
 
 let _ =


### PR DESCRIPTION
Things worth noting:

- Circular dependency from `List -> String -> List` hinders implementation of `List.to_string` (maybe that's why the standard library doesn't have it?). I decided to cut off the dependency `String -> List`, since `List.to_string` must use `String` module.
- I didn't put `to_string` functions for `temp_func` into `Pretty` module, since I plan to hide the representation of datatypes in `X86` later, since no more downstream modules would use it any further (it's the end of our compiler pipeline).