### PR TITLE
Fix spilling

### DIFF
--- a/lib/backend/x86.ml
+++ b/lib/backend/x86.ml
@@ -771,9 +771,8 @@ let _spill_ctx_init temp_func (temps_to_spill : Temp.t Set.t) : spill_context =
             ; temp_manager = temp_func.temp_manager
             }
   in
-  let args_to_spill = List.fold_right Set.remove temp_func.args temps_to_spill in
-  let ctx, temp_slot_pairs =
-    _get_or_gen_slots_for_temps_to_spill ctx args_to_spill in
+  let args = List.fold_right Set.add temp_func.args (Set.empty Temp.compare) in
+  let ctx, temp_slot_pairs = _get_or_gen_slots_for_temps_to_spill ctx args in
   List.fold_left (* order doesn't matter *)
     (fun ctx (temp, slot) -> _spill_to_slot ctx temp slot)
   ctx temp_slot_pairs

--- a/lib/backend/x86.ml
+++ b/lib/backend/x86.ml
@@ -68,10 +68,11 @@ type prog =
   }
 
 type temp_func = 
-  { entry  : Label.t
-  ; instrs : Temp.t instr list
-  ; args   : Temp.t list
-  ; rax    : Temp.t
+  { entry        : Label.t
+  ; instrs       : Temp.t instr list
+  ; args         : Temp.t list
+  ; rax          : Temp.t
+  ; temp_manager : Temp.manager
   }
 
 type temp_prog = 
@@ -414,10 +415,11 @@ let _from_lir_func (label_manager : Label.manager) (lir_func : Lir.func)
   let ctx = _init_ctx lir_func.name args lir_func.temp_manager label_manager in
   let ctx = _emit_load_args_into_temps ctx args in
   let ctx = _emit_lir_instrs ctx lir_func.body in
-  let func = { entry  = lir_func.name
-             ; instrs = _ctx_get_instrs ctx
-             ; args   = ctx.ordered_arg_temps
-             ; rax    = ctx.rax_temp
+  let func = { entry        = lir_func.name
+             ; instrs       = _ctx_get_instrs ctx
+             ; args         = ctx.ordered_arg_temps
+             ; rax          = ctx.rax_temp
+             ; temp_manager = lir_func.temp_manager
              }
   in (func, ctx.label_manager)
 ;;
@@ -442,10 +444,11 @@ let _from_lir_main_func
   let entry_label = Label.get_native Constants.entry_name in
   let ctx = _init_ctx entry_label [] temp_manager label_manager in
   let ctx = _emit_lir_instrs ctx lir_instrs in
-  { entry  = ctx.func_label
-  ; instrs = _ctx_get_instrs ctx
-  ; args   = ctx.ordered_arg_temps
-  ; rax    = ctx.rax_temp
+  { entry        = ctx.func_label
+  ; instrs       = _ctx_get_instrs ctx
+  ; args         = ctx.ordered_arg_temps
+  ; rax          = ctx.rax_temp
+  ; temp_manager = ctx.temp_manager
   } 
 ;;
 

--- a/lib/backend/x86.mli
+++ b/lib/backend/x86.mli
@@ -64,9 +64,10 @@ type 'a instr =
  * NOTE without prologue/epilogue. *) 
 type temp_func = 
   { entry  : Label.t
-  ; instrs : Temp.t instr list (* doesn't start with [entry] label *)
-  ; args   : Temp.t list       (* for each arg reg; might not all be used *)
+  ; instrs : Temp.t instr list  (* doesn't start with [entry] label *)
+  ; args   : Temp.t list        (* for each arg reg; might not all be used *)
   ; rax    : Temp.t
+  ; temp_manager : Temp.manager (* for generating fresh temps *)
   }
 
 (* A program in X86 before register allocation *)

--- a/test/integration/test_integration.ml
+++ b/test/integration/test_integration.ml
@@ -116,6 +116,7 @@ let _create_ounit_test (test_name : string) : OUnit2.test =
 let tests = OUnit2.(>:::) "test_integration"
     (Stdlib.List.map _create_ounit_test
        [ 
+         "basic";
        ])
 
 let _ =


### PR DESCRIPTION
Fixes #29. Refer to it for more context and details.

## Gist
For any temp to be spilled, always 
- write it to a fixed slot on stack right after write
- restore it into a __new unique__ temp right before read, and use the new temp in the instruction

## Potential Optimizations
0. Graph-coloring based allocator that accounts for interferences from a global perspective. (a simple `print (1 + 2)` shows how the greedy algorithm creates unnecessary spills due to lack of global perspective)
1. Calculate interference based on live-ranges (or essentially rename the temps based on live-ranges).
2. Don't spill _all_ usage of temps -- only spill the one of them (i.e. break up 1 def-use chain part of live-interval)? Might take too many iterations in that case.