### PR TITLE
Fix stack frame size calculation

### DIFF
--- a/lib/backend/x86.ml
+++ b/lib/backend/x86.ml
@@ -660,6 +660,7 @@ let _get_max_rbp_offset_instr (instr : 'a instr) : int =
   match instr with
   | Label _ -> 0
   | Load (arg, _) -> _get_max_rbp_offset_arg arg
+  | Store (_, Rbp, offset) -> Int.max 0 (-offset)
   | Store (_, _, _) -> 0
   | Push _ -> 0
   | Pop _ -> 0

--- a/lib/backend/x86.ml
+++ b/lib/backend/x86.ml
@@ -646,41 +646,44 @@ let temp_func_to_vasms temp_func =
 ;;
 
 
-let _get_max_rbp_offset_arg (arg : 'a arg) : int =
-  match arg with
-  | Mem_arg (Rbp, offset) -> Int.max 0 (-offset)
-                      (* ignore positive offset since stack grows downward *)
-  | Lbl_arg _             -> 0
-  | Imm_arg _             -> 0
-  | Reg_arg _             -> 0
-  | Mem_arg (_, _)        -> 0
-;;
-
-let _get_max_rbp_offset_instr (instr : 'a instr) : int =
-  match instr with
-  | Label _ -> 0
-  | Load (arg, _) -> _get_max_rbp_offset_arg arg
-  | Store (_, Rbp, offset) -> Int.max 0 (-offset)
-  | Store (_, _, _) -> 0
-  | Push _ -> 0
-  | Pop _ -> 0
-  | Binop (_, _, arg) -> _get_max_rbp_offset_arg arg
-  | Cmp (arg, _) -> _get_max_rbp_offset_arg arg
-  | Jmp _ -> 0
-  | JmpC _ -> 0
-  | Call _ -> 0
-  | Ret ->  0
-;;
-
 (* NOTE 
  * - ignore push/pop since that changes rsp dynamically.
  * - look for negative offset only since stack grows downward,
  *   BUT RETURN POSITIVE offset for convenience. *)
 let _get_max_rbp_offset_instrs (instrs : 'a instr list) : int =
-  List.fold_left
-    (fun max instr ->
-       Int.max max (_get_max_rbp_offset_instr instr))
-    0 instrs
+
+  let _get_offset (offset : int) : int =
+    Int.max 0 (-offset)
+  in
+
+  let _get_rbp_offset_arg (arg : 'a arg) : int =
+    match arg with
+    | Mem_arg (Rbp, offset) -> _get_offset offset
+                        (* ignore positive offset since stack grows downward *)
+    | Lbl_arg _             -> 0
+    | Imm_arg _             -> 0
+    | Reg_arg _             -> 0
+    | Mem_arg (_, _)        -> 0
+  in
+  
+  let _get_rbp_offset_instr (instr : 'a instr) : int =
+    match instr with
+    | Label _ -> 0
+    | Load (arg, _) -> _get_rbp_offset_arg arg
+    | Store (_, Rbp, offset) -> _get_offset offset
+    | Store (_, _, _) -> 0
+    | Push _ -> 0
+    | Pop _ -> 0
+    | Binop (_, _, arg) -> _get_rbp_offset_arg arg
+    | Cmp (arg, _) -> _get_rbp_offset_arg arg
+    | Jmp _ -> 0
+    | JmpC _ -> 0
+    | Call _ -> 0
+    | Ret ->  0
+  in
+
+  let offsets = List.map _get_rbp_offset_instr instrs in
+  List.fold_left Int.max 0 offsets
 ;;
 
 (* Yeah yeah internal modules; but bootstrapping takes priority *)


### PR DESCRIPTION
I forgot to account for RBP offset in `Store` (move reg to memory).

Interestingly I don't think this will produce any bug _for now_, because such store comes from spill only, and _I think_ we only spill temps that'll be used later (else its assigned register becomes immediately available after first definition). So if a spilled temp is always used later, it'll be restored, and the RBP offset in `Store` will be accounted for in the Load instruction there.

I also decided to move the helpers into the main offset calculation function. It's confusing that we are returning the positive offset, although looking for negative ones because stack grows downward. Encapsulate those functions and document this at the main function should make the code clearer.