### PR TITLE
Fix lir to x86 temp func transl

### DIFF
--- a/lib/backend/x86.ml
+++ b/lib/backend/x86.ml
@@ -449,7 +449,7 @@ let _from_lir_func (label_manager : Label.manager) (lir_func : Lir.func)
              ; instrs       = _ctx_get_instrs ctx
              ; args         = ctx.ordered_arg_temps
              ; rax          = ctx.rax_temp
-             ; temp_manager = lir_func.temp_manager
+             ; temp_manager = ctx.temp_manager
              }
   in (func, ctx.label_manager)
 ;;

--- a/lib/backend/x86.ml
+++ b/lib/backend/x86.ml
@@ -476,8 +476,10 @@ let _from_lir_main_func
     (label_manager : Label.manager)
     (body_instrs : Lir.instr list)
   : temp_func =
-  (* TODO call "soml_init" here, or make this a function called by C runtime?
-   * TBD when implementing runtime. *)
+  (* NOTE assume the entry function 
+   * - is invoked by runtime with the designated label
+   * - has no args 
+   * MUST synch with C runtime *)
   let main_entry = Label.get_native Constants.entry_name in
   _from_lir_func_impl label_manager temp_manager main_entry [] body_instrs
   |> (fun (temp_func, _) -> temp_func)


### PR DESCRIPTION
Takeaways:
- SPoC should be done ASAP, not pushed back for refactoring later.
- Without inlined tests, it's hard to test internal invariants without exposing underlying impls, which pollutes the interface. (I intend to hide X86's datatypes later)