### PR TITLE
Fix tyvar namer

### DIFF
--- a/test/soc/dune
+++ b/test/soc/dune
@@ -6,7 +6,7 @@
 
    ; frontend
    location_test span_test lexer_test parser_test ast_interp_test typer_test
-   substs_test
+   substs_test tyvar_namer_test
 
    ; backend
    cir_test var_namer_test temp_test label_test graph_test

--- a/test/soc/frontend/typing/resources/typer_input_mixed.expect
+++ b/test/soc/frontend/typing/resources/typer_input_mixed.expect
@@ -1,3 +1,4 @@
+[Typer]: Expected type <int> but got <bool> at <(7, 3)-(7, 7)>
 [Typer]: Expected type <int -> 'X31 -> 'X30> but got <int -> int> at <(22, 1)-(22, 1)>
 [Typer]: Illegal rhs of let rec binding at <(32, 13)-(32, 15)>
 [Typer]: Illegal rhs of let rec binding at <(35, 13)-(35, 17)>

--- a/test/soc/frontend/typing/resources/typer_input_mixed.soml
+++ b/test/soc/frontend/typing/resources/typer_input_mixed.soml
@@ -1,6 +1,6 @@
 
 let rec f = (fun (x : 'a) -> x)
-and g = (fun (x : 'a) -> x)
+and g = (fun (x : 'a) -> x + 1)
 ;;
 
 f 12;;

--- a/test/soc/frontend/typing/tyvar-namer-resources/tyvars.expect
+++ b/test/soc/frontend/typing/tyvar-namer-resources/tyvars.expect
@@ -1,0 +1,8 @@
+let rec (f : 'X0) = (fun (x : 'X1) -> + x 1)
+and (g : 'X2) = (fun (x : 'X1) -> x)
+;;
+
+g 12
+
+g false
+

--- a/test/soc/frontend/typing/tyvar-namer-resources/tyvars.soml
+++ b/test/soc/frontend/typing/tyvar-namer-resources/tyvars.soml
@@ -1,0 +1,7 @@
+let rec f = (fun (x : 'a) -> x + 1)
+and g = (fun (x : 'a) -> x)
+;;
+
+g 12;;
+g false;;
+

--- a/test/soc/frontend/typing/tyvar_namer_test.ml
+++ b/test/soc/frontend/typing/tyvar_namer_test.ml
@@ -1,0 +1,36 @@
+open Pervasives
+
+(* [filename] can assume CWD is where this file is *)
+let _get_full_path (filename : string) : string =
+  String.append "../../../../test/soc/frontend/typing/tyvar-namer-resources/" filename
+;;
+
+let _check_renamed_ast_pp (filepath_no_suffix : string) : unit =
+  let filepath = String.append filepath_no_suffix ".soml" in
+  let result =
+    match Driver.parse_file filepath with
+    | Error msg -> msg
+    | Ok ast -> 
+      let namer = Tyvar_namer.init in
+      let _, ast = Tyvar_namer.rename_struct namer ast in
+      Pretty.pp_ast_structure ast
+  in
+  let expect_path = String.append filepath_no_suffix ".expect" in
+  let actual_path = String.append filepath_no_suffix ".actual" in
+  Test_aux.check_and_output_str result expect_path actual_path;
+;;
+
+
+let tests = OUnit2.(>:::) "tyvar_namer_test" [
+
+    OUnit2.(>::) "test_integration" (fun _ ->
+        List.iter
+          (fun name -> _check_renamed_ast_pp (_get_full_path name))
+          [
+            "tyvars";
+          ]
+      );
+  ]
+
+let _ =
+  OUnit2.run_test_tt_main tests


### PR DESCRIPTION
`Tyvar_namer` failed to capture dependency of tyvars between arguments of different functions.

See 844378b for the cause and fix.

See e73d53b for the regression test added for `Tyvar_namer`.

__Lesson__ unit tests really keep your butt covered.