### PR TITLE
Add live_across information to liveness annotation.

### DIFF
--- a/lib/backend/liveness_analysis.ml
+++ b/lib/backend/liveness_analysis.ml
@@ -106,6 +106,7 @@ open Pervasives
 type annot =
   { live_in  : Temp.t Set.t
   ; live_out : Temp.t Set.t
+  ; live_across : Temp.t Set.t
   }
 
 type block_annot =
@@ -180,7 +181,11 @@ let _annot_instructions_in_block
        let reads, writes = (Vasm.get_reads instr, Vasm.get_writes instr) in
        let new_live_out = Set.diff live_out writes in
        let new_live_out = Set.union new_live_out reads in
-       let annot = { live_in = new_live_out; live_out } in
+       let annot = { live_in = new_live_out
+                   ; live_out 
+                   ; live_across =
+                       Set.diff (Set.inter live_out new_live_out) writes
+                   } in
        let annot_instrs = (instr, annot)::annot_instrs in
        (annot_instrs, new_live_out))
     block ([], block_annot.live_out)

--- a/lib/backend/liveness_analysis.mli
+++ b/lib/backend/liveness_analysis.mli
@@ -3,8 +3,11 @@ open Pervasives
 (* An [annot] is an annotation for a single [Vasm.t] *)
 type annot =
   (* Temps whose definition before/after an instruction might be used later *)
-  { live_in  : Temp.t Set.t 
-  ; live_out : Temp.t Set.t 
+  { live_in     : Temp.t Set.t 
+  ; live_out    : Temp.t Set.t 
+  (* Temps from intersection of [live_in] and [live_out] whose definition isn't
+   * killed by an instruction *)
+  ; live_across : Temp.t Set.t
   }
 
 

--- a/lib/backend/reg_alloc.ml
+++ b/lib/backend/reg_alloc.ml
@@ -243,9 +243,8 @@ let _brute_color_temps_live_across_call
   else
     (* Any temp that lives across a call must be mapped to callee-saved or
      * spilled. *)
-    let temps_live_across_call = Set.inter annot.live_out annot.live_in in
     let temp_color_pairs, temps_to_color =
-      extract_colored_temps temps_live_across_call
+      extract_colored_temps annot.live_across
     in
     let temps_to_spill = (* must spill temps pre-colored to caller-saved *)
       add_temps_colored_to_caller_saved init_temps_to_spill temp_color_pairs

--- a/test/soc/backend/backend_aux.ml
+++ b/test/soc/backend/backend_aux.ml
@@ -8,7 +8,12 @@ let mk_annotated_vasms live_in vasm_live_out_set_pairs =
   List.fold_left
     (fun (live_in, rev_annot_instrs) (instr, live_out) ->
        let live_out = temps_to_set live_out in
-       let annot = { Liveness_analysis.live_in; live_out } in
+       let annot = { Liveness_analysis.live_in
+                   ; live_out
+                   ; live_across = Set.diff
+                         (Set.union live_in live_out)
+                         (Vasm.get_writes instr)
+                   } in
        let rev_annot_instrs = (instr, annot)::rev_annot_instrs in
        (live_out, rev_annot_instrs))
     (temps_to_set live_in, [])


### PR DESCRIPTION
`live_across != intersection(live_in, live_out)` because a temp from `live_in` could be re-written and used after this instruction, but its old definition was "killed" by the instruction, e.g., `T1 := T1 + 1`.

The only place we're using this incorrect formula is register allocator, but fortunately (or unfortunately really) it never triggered  any bug, because currently call instruction only writes to `RAX`, but `RAX` is not read by call instruction.