### PR TITLE
Refactor x86

### DIFF
--- a/lib/backend/reg_alloc.mli
+++ b/lib/backend/reg_alloc.mli
@@ -5,8 +5,8 @@ open Pervasives
     - Ok: a valid coloring for instructions in instr_annot_pair. It's guaranteed
       to be a "super-map" of [pre_colored]
 
-    - Error: A set of temps that should be spilled (may spill more or less than
-      what's needed, but repeated application will ensure termination, I hope) 
+    - Error: A set of temps that should be spilled, without any key from
+      [pre_colored]
 
     It's greedy because it linear scans all the instructions and immediately
     assign available color to the temps, without backtracking or a global view.

--- a/lib/backend/x86.ml
+++ b/lib/backend/x86.ml
@@ -20,16 +20,57 @@ let ordered_argument_physical_regs =
   [Rdi; Rsi; Rdx; Rcx; R8; R9]
 ;;
 
+let _physical_reg_to_int (pr : physical_reg) : int =
+  match pr with
+  | Rax -> 0
+  | Rbx -> 1
+  | Rsi -> 2
+  | Rdi -> 3
+  | Rdx -> 4
+  | Rcx -> 5
+  | R8  -> 6
+  | R9  -> 7
+  | R10 -> 8
+  | R11 -> 9
+  | R12 -> 10
+  | R13 -> 11
+  | R14 -> 12
+  | R15 -> 13
+;;
+
+let _compare_physical_reg r1 r2 =
+  Int.compare (_physical_reg_to_int r1) (_physical_reg_to_int r2)
+;;
+
+let _physical_reg_list_to_set (prs : physical_reg list) : physical_reg Set.t =
+  List.fold_right Set.add prs (Set.empty _compare_physical_reg)
+;;
+
+let caller_saved_physical_regs =
+  _physical_reg_list_to_set [Rdi; Rsi; Rdx; Rcx; R8; R9; Rax; R11; R12]
+;;
+
+let callee_saved_physical_regs =
+  _physical_reg_list_to_set [Rbx; R12; R13; R14; R15]
+;;
+
+let rax_physical_reg = Rax
+;;
+
+let rdx_physical_reg = Rdx
+;;
+
+
 type 'a reg =
-  | Rsp        
-  | Rbp        
-  | Greg of 'a 
+  | Rsp        (* not sure how allowing this in reg-alloc would affect things *)
+  | Rbp        (* we need rbp for spilling *)
+  | Greg of 'a (* general purpose registers *)
 
 type 'a arg =
-  | Lbl_arg of Label.t
-  | Imm_arg of int
-  | Reg_arg of 'a reg
-  | Mem_arg of 'a reg * int
+  | Lbl_arg of Label.t      (* label, e.g., use function label as data *)
+  | Imm_arg of int          (* immediate, i.e., constants*)
+  | Reg_arg of 'a reg       (* load from [reg] *)
+  | Mem_arg of 'a reg * int (* load from address [reg + offset] *)
 
 type cond =
   | Eq
@@ -44,39 +85,59 @@ type 'a call_target =
   | Reg of 'a
   | Lbl of Label.t
 
+(* NOTE 
+ * 0. I'm not being truthful to the X86 ISA here. I really took a subset of it
+ *    for simplicity, and since we don't need the other fancy instrs for now.
+ * 1. Many instructions don't support 2 memory accesses, I made that explicit.
+ *)
 type 'a instr = 
   | Label of Label.t
   | Load of 'a arg * 'a reg
+      (* Load (arg, reg) --> reg := arg *)
   | Store of 'a reg * 'a reg * int
+      (* Store (sreg, dreg, offset) --> *[dreg + offset] := sreg *)
   | Push of 'a reg
   | Pop of 'a reg
   | IDiv of 'a reg
+      (* [IDiv r] does signed division for [RDX:RAX] over [r].
+      * The quotient is stoed to [RAX], remainder to [RDX] *)
   | Binop of binop * 'a reg * 'a arg
+      (* Binop (op, reg, arg) --> reg := op gr arg *)
   | Cmp of 'a arg * 'a
   | Jmp of Label.t
   | JmpC of cond * Label.t
+      (* Jump to label if [cond] is satisfied. *)
   | Call of 'a call_target * 'a list
+      (* Target and arguments that are passed in registers in no specific order.
+       * The arguments are used for debugging or liveness analysis purposes *)
   | Ret
+      (* Return control flow to caller site *)
+
 
 type func =
   { entry  : Label.t
-  ; instrs : physical_reg instr list
+  ; instrs : physical_reg instr list (* doesn't start with [entry] label *)
   }
 
+(* An entire program in X86 after register allocation *)
 type prog = 
   { funcs : func list
   ; main : func
   }
 
+
+(* With some annotations to help reg-alloc. *)
 type temp_func = 
-  { entry        : Label.t
-  ; instrs       : Temp.t instr list
-  ; reg_args     : Temp.t list
-  ; rax          : Temp.t
-  ; rdx          : Temp.t
-  ; temp_manager : Temp.manager
+  { entry    : Label.t
+  ; instrs   : Temp.t instr list  (* doesn't start with [entry] label *)
+  ; reg_args : Temp.t list        (* for each argument passed in register;
+                                     might not all be used *)
+  ; rax      : Temp.t
+  ; rdx      : Temp.t
+  ; temp_manager : Temp.manager (* for generating fresh temps *)
   }
 
+(* A program in X86 before register allocation *)
 type temp_prog = 
   { temp_funcs : temp_func list
   ; temp_main  : temp_func
@@ -615,6 +676,20 @@ let temp_func_to_vasms temp_func =
 ;;
 
 
+let get_pre_coloring temp_func =
+  let pre_color = Map.empty Temp.compare in
+  let temp_reg_pairs =
+    (temp_func.rax, Rax)::
+    (temp_func.rdx, Rdx)::
+    (List.combine temp_func.reg_args ordered_argument_physical_regs)
+  in
+  List.fold_left
+    (fun pre_color (temp, reg) ->
+       Map.add temp reg pre_color)
+    pre_color temp_reg_pairs
+;;
+
+
 (* NOTE 
  * - ignore push/pop since that changes rsp dynamically.
  * - look for negative offset only since stack grows downward,
@@ -820,47 +895,6 @@ let spill_temps temp_func temps_to_spill =
   { temp_func with instrs       = List.rev ctx.rev_instrs 
                  ; temp_manager = ctx.temp_manager
   }
-;;
-
-
-let _physical_reg_to_int (pr : physical_reg) : int =
-  match pr with
-  | Rax -> 0
-  | Rbx -> 1
-  | Rsi -> 2
-  | Rdi -> 3
-  | Rdx -> 4
-  | Rcx -> 5
-  | R8  -> 6
-  | R9  -> 7
-  | R10 -> 8
-  | R11 -> 9
-  | R12 -> 10
-  | R13 -> 11
-  | R14 -> 12
-  | R15 -> 13
-;;
-
-let _compare_physical_reg r1 r2 =
-  Int.compare (_physical_reg_to_int r1) (_physical_reg_to_int r2)
-;;
-
-let _physical_reg_list_to_set (prs : physical_reg list) : physical_reg Set.t =
-  List.fold_right Set.add prs (Set.empty _compare_physical_reg)
-;;
-
-let caller_saved_physical_regs =
-  _physical_reg_list_to_set [Rdi; Rsi; Rdx; Rcx; R8; R9; Rax; R11; R12]
-;;
-
-let callee_saved_physical_regs =
-  _physical_reg_list_to_set [Rbx; R12; R13; R14; R15]
-;;
-
-let rax_physical_reg = Rax
-;;
-
-let rdx_physical_reg = Rdx
 ;;
 
 

--- a/lib/driver.ml
+++ b/lib/driver.ml
@@ -42,16 +42,7 @@ let lir_file filepath =
 let rec _x86_temp_func_to_func (temp_func : X86.temp_func) : X86.func =
   let vasms = X86.temp_func_to_vasms temp_func in
   let annotated_vasms = Liveness_analysis.analyze_vasm vasms in
-  let pre_color = Map.empty Temp.compare in
-  let pre_color = Map.add temp_func.rax X86.rax_physical_reg pre_color in
-  let pre_color = Map.add temp_func.rdx X86.rdx_physical_reg pre_color in
-  let pre_color =
-    List.fold_left
-      (fun pre_color (arg_temp, arg_reg) ->
-         Map.add arg_temp arg_reg pre_color)
-      pre_color
-      (List.combine temp_func.reg_args X86.ordered_argument_physical_regs)
-  in
+  let pre_color = X86.get_pre_coloring temp_func in
   match Reg_alloc.greedy_alloc
           annotated_vasms 
           X86.caller_saved_physical_regs


### PR DESCRIPTION
Downstream tasks from X86 are limited, so I decided to hide most of the implementation datatypes.
It significantly simplifies the interface, and makes it easier to experiment with different underlying representations.