### PR TITLE
Fix arg regs

### DIFF
--- a/lib/backend/x86.ml
+++ b/lib/backend/x86.ml
@@ -16,34 +16,33 @@ type physical_reg =
   | R14
   | R15
 
-let ordered_argument_physical_regs =
-  [Rdi; Rsi; Rdx; Rcx; R8; R9]
-;;
-
-let _physical_reg_to_int (pr : physical_reg) : int =
-  match pr with
-  | Rax -> 0
-  | Rbx -> 1
-  | Rsi -> 2
-  | Rdi -> 3
-  | Rdx -> 4
-  | Rcx -> 5
-  | R8  -> 6
-  | R9  -> 7
-  | R10 -> 8
-  | R11 -> 9
-  | R12 -> 10
-  | R13 -> 11
-  | R14 -> 12
-  | R15 -> 13
-;;
-
 let _compare_physical_reg r1 r2 =
+  let _physical_reg_to_int (pr : physical_reg) : int =
+    match pr with
+    | Rax -> 0
+    | Rbx -> 1
+    | Rsi -> 2
+    | Rdi -> 3
+    | Rdx -> 4
+    | Rcx -> 5
+    | R8  -> 6
+    | R9  -> 7
+    | R10 -> 8
+    | R11 -> 9
+    | R12 -> 10
+    | R13 -> 11
+    | R14 -> 12
+    | R15 -> 13
+  in
   Int.compare (_physical_reg_to_int r1) (_physical_reg_to_int r2)
 ;;
 
 let _physical_reg_list_to_set (prs : physical_reg list) : physical_reg Set.t =
   List.fold_right Set.add prs (Set.empty _compare_physical_reg)
+;;
+
+let ordered_argument_physical_regs =
+  [Rdi; Rsi; Rdx; Rcx; R8; R9]
 ;;
 
 let caller_saved_physical_regs =

--- a/lib/backend/x86.ml
+++ b/lib/backend/x86.ml
@@ -47,7 +47,7 @@ let _physical_reg_list_to_set (prs : physical_reg list) : physical_reg Set.t =
 ;;
 
 let caller_saved_physical_regs =
-  _physical_reg_list_to_set [Rdi; Rsi; Rdx; Rcx; R8; R9; Rax; R11; R12]
+  _physical_reg_list_to_set [Rdi; Rsi; Rdx; Rcx; R8; R9; Rax; R10; R11]
 ;;
 
 let callee_saved_physical_regs =


### PR DESCRIPTION
See f3a94f9, I'm surprised that this didn't raise any bug.

In retrospect, I think it's because adding callee-saved regs into caller-saved regs doesn't really affect correctness (they are just used for normal coloring anyway). On the other hand, if the bug was the other way around, things would break because the abused caller-saved regs might get assigned to temps that live across call, but they could get clobbered.