### PR TITLE
Refactor x86 special purpose temps

### DIFF
--- a/lib/backend/x86.ml
+++ b/lib/backend/x86.ml
@@ -687,8 +687,8 @@ let _get_reads_and_writes_temp_instr
     (reads, writes)
 ;;
 
-let _temp_instr_to_vasm (rax : Temp.t) (rdx : Temp.t) (instr : Temp.t instr)
-  : Vasm.t =
+let _temp_instr_to_vasm (sp_temps : sp_temps) (instr : Temp.t instr) : Vasm.t =
+  let rax, rdx = sp_temps.rax, sp_temps.rdx in
   let reads, writes = _get_reads_and_writes_temp_instr rax rdx instr in
   let reads, writes = Set.to_list reads, Set.to_list writes in
   match instr with
@@ -706,8 +706,8 @@ let _temp_instr_to_vasm (rax : Temp.t) (rdx : Temp.t) (instr : Temp.t instr)
 ;;
 
 let temp_func_to_vasms (temp_func : temp_func) =
-  let rax, rdx = temp_func.sp_temps.rax, temp_func.sp_temps.rdx in
-  let body_vasms = List.map (_temp_instr_to_vasm rax rdx) temp_func.instrs in
+  let sp_temps = temp_func.sp_temps in
+  let body_vasms = List.map (_temp_instr_to_vasm sp_temps) temp_func.instrs in
   let entry_label = Vasm.mk_label temp_func.entry in
   entry_label::body_vasms
 ;;

--- a/lib/backend/x86.ml
+++ b/lib/backend/x86.ml
@@ -765,8 +765,7 @@ type spill_context =
   ; slot_map       : (Temp.t, int) Map.t    (* keys ∈ [temps_to_spill] *)
   ; rev_instrs     : Temp.t instr list
   ; temps_to_spill : Temp.t Set.t
-  ; rax_temp       : Temp.t
-  ; rdx_temp       : Temp.t
+  ; sp_temps       : sp_temps
   ; temp_manager   : Temp.manager
   }
 
@@ -864,8 +863,7 @@ let _spill_ctx_init temp_func (temps_to_spill : Temp.t Set.t) : spill_context =
             ; slot_map     = Map.empty Temp.compare 
             ; rev_instrs   = []
             ; temps_to_spill
-            ; rax_temp     = temp_func.sp_temps.rax
-            ; rdx_temp     = temp_func.sp_temps.rdx
+            ; sp_temps     = temp_func.sp_temps
             ; temp_manager = temp_func.temp_manager
             }
   in
@@ -883,7 +881,7 @@ let _spill_ctx_init temp_func (temps_to_spill : Temp.t Set.t) : spill_context =
 let _spill_instr (ctx : spill_context) (instr : Temp.t instr) : spill_context =
   (* ASSUME instruction goes like read/compute/write *)
   let reads, writes =
-    _get_reads_and_writes_temp_instr ctx.rax_temp ctx.rdx_temp instr
+    _get_reads_and_writes_temp_instr ctx.sp_temps.rax ctx.sp_temps.rdx instr
   in
   let ctx, changed_temp_map = _restore_all_spilled ctx reads in
   let old_to_new_temp temp =


### PR DESCRIPTION
Addresses concern raised in #39.

Essentially, we centralize management of temps that represent special-purpose registers in X86.