### PR TITLE
Simplify reg alloc

### DIFF
--- a/lib/backend/reg_alloc.ml
+++ b/lib/backend/reg_alloc.ml
@@ -32,9 +32,9 @@ type 'a context =
 let _ctx_init
     (avalb_colors : 'a Set.t)
     (pre_coloring : (Temp.t, 'a) Map.t)
-    (temps_to_spill : Temp.t Set.t)
   : 'a context =
-  { avalb_colors;  temps_to_spill;
+  { avalb_colors; 
+    temps_to_spill   = Set.empty Temp.compare;
     coloring         = pre_coloring;
     temps_cant_spill = Map.get_key_set pre_coloring;
     temps_in_use     = Set.empty Temp.compare;
@@ -198,80 +198,6 @@ let _brute_alloc_impl
       ctx annot_instrs
 ;;
 
-let _brute_color_temps_live_across_call
-    (init_coloring : (Temp.t, 'a) Map.t) (init_temps_to_spill : Temp.t Set.t)
-    (callee_saved : 'a Set.t) (vasm : Vasm.t) (annot : Liveness_analysis.annot) 
-  : ((Temp.t, 'a) Map.t * Temp.t Set.t) =
-
-  let extract_colored_temps temp_set
-    : ((Temp.t * 'a) list * Temp.t list) =
-    Set.fold
-      (fun (temp_color_pairs, uncolored_temps) temp ->
-         match Map.get temp init_coloring with
-         | Some color -> ((temp, color)::temp_color_pairs, uncolored_temps)
-         | None       -> (temp_color_pairs, temp::uncolored_temps))
-      ([], []) temp_set
-  in
-
-  let add_temps_colored_to_caller_saved temp_set (coloring : (Temp.t * 'a) list)
-    : Temp.t Set.t =
-    List.fold_left 
-      (fun temps_to_spill (temp, color) ->
-         if Set.mem color callee_saved then temps_to_spill
-         else Set.add temp temps_to_spill)
-      temp_set coloring
-  in
-
-  let color_to_callee_saved_or_spill
-      (coloring : (Temp.t, 'a) Map.t)
-      (temps_to_spill : Temp.t Set.t)
-      (temps_to_color : Temp.t list)
-    : (Temp.t, 'a) Map.t * Temp.t Set.t =
-    List.fold_left (* color the rest to callee-saved, as much as possible *)
-      (fun (avalb_colors, pre_colored, temps_to_spill) temp ->
-         match Set.get_one avalb_colors with
-         | Some color -> 
-           if Set.mem temp temps_to_spill
-           then (avalb_colors, pre_colored, temps_to_spill)
-           else
-             let avalb_colors = Set.remove color avalb_colors in
-             let pre_colored = Map.add temp color pre_colored in
-             (avalb_colors, pre_colored, temps_to_spill)
-         (* don't waste color for already spilled temp *)
-         | _ -> (avalb_colors, pre_colored, Set.add temp temps_to_spill))
-      (callee_saved, coloring, temps_to_spill)
-      temps_to_color
-    |> (fun (_, pre_colored, temps_to_spill) -> (pre_colored, temps_to_spill))
-  in
-
-  if not (Vasm.is_call vasm) then (init_coloring, init_temps_to_spill)
-  else
-    (* Any temp that lives across a call must be mapped to callee-saved or
-     * spilled. *)
-    let temps_live_across_call = Set.inter annot.live_out annot.live_in in
-    let temp_color_pairs, temps_to_color =
-      extract_colored_temps temps_live_across_call
-    in
-    let temps_to_spill = (* must spill temps pre-colored to caller-saved *)
-      add_temps_colored_to_caller_saved init_temps_to_spill temp_color_pairs
-    in
-    color_to_callee_saved_or_spill init_coloring temps_to_spill temps_to_color
-;;
-
-(* pre-color temps that live through Call instructions to callee-saved regs *)
-let _brute_pre_color_call_temps
-    (annot_instrs : (Vasm.t * Liveness_analysis.annot) list)
-    (callee_saved : 'a Set.t)
-    (pre_colored  : (Temp.t, 'a) Map.t)
-  : ((Temp.t, 'a) Map.t * Temp.t Set.t) =
-  List.fold_left
-    (fun (pre_colored, temps_to_spill)  (instr, annot) ->
-       _brute_color_temps_live_across_call
-         pre_colored temps_to_spill callee_saved instr annot)
-    (pre_colored, Set.empty Temp.compare)
-    annot_instrs
-;;
-
 (* REQUIRES:
  * 1. [caller_saved] and [callee_saved] are disjoint
  * 2. anoot_instrs has accurate liveness annotation (exposed for eaiser testing)
@@ -282,10 +208,8 @@ let greedy_alloc
     (callee_saved : 'a Set.t)
     (pre_colored  : (Temp.t, 'a) Map.t)
   : ((Temp.t, 'a) Map.t, Temp.t Set.t) result =
-  let pre_colored, temps_to_spill =
-    _brute_pre_color_call_temps annot_instrs callee_saved pre_colored in
   let all_regs = Set.union caller_saved callee_saved in
-  let ctx = _ctx_init all_regs pre_colored temps_to_spill in
+  let ctx = _ctx_init all_regs pre_colored in
   let ctx = _brute_alloc_impl ctx annot_instrs in
   if Set.size ctx.temps_to_spill = 0
   then Ok ctx.coloring

--- a/lib/backend/reg_alloc.ml
+++ b/lib/backend/reg_alloc.ml
@@ -198,18 +198,12 @@ let _brute_alloc_impl
       ctx annot_instrs
 ;;
 
-(* REQUIRES:
- * 1. [caller_saved] and [callee_saved] are disjoint
- * 2. anoot_instrs has accurate liveness annotation (exposed for eaiser testing)
- *)
 let greedy_alloc 
     (annot_instrs : (Vasm.t * Liveness_analysis.annot) list)
-    (caller_saved : 'a Set.t)
-    (callee_saved : 'a Set.t)
+    (available_regs : 'a Set.t)
     (pre_colored  : (Temp.t, 'a) Map.t)
   : ((Temp.t, 'a) Map.t, Temp.t Set.t) result =
-  let all_regs = Set.union caller_saved callee_saved in
-  let ctx = _ctx_init all_regs pre_colored in
+  let ctx = _ctx_init available_regs pre_colored in
   let ctx = _brute_alloc_impl ctx annot_instrs in
   if Set.size ctx.temps_to_spill = 0
   then Ok ctx.coloring

--- a/lib/backend/reg_alloc.mli
+++ b/lib/backend/reg_alloc.mli
@@ -1,6 +1,6 @@
 open Pervasives
 
-(** [greedy_alloc instr_annot_pair caller_saved callee_saved pre_colored] returns 
+(** [greedy_alloc instr_annot_pair available_regs pre_colored] returns 
   
     - Ok: a valid coloring for instructions in instr_annot_pair. It's guaranteed
       to be a "super-map" of [pre_colored]
@@ -12,10 +12,9 @@ open Pervasives
     assign available color to the temps, without backtracking or a global view.
 
     NOTE Undefined behavior if 
-    - [caller_saved] and [callee_saved] sets are not disjoint, 
     - any liveness annotation is inaccurate. *)
 val greedy_alloc :
   (Vasm.t * Liveness_analysis.annot) list ->
-  'a Set.t -> 'a Set.t ->
+  'a Set.t ->
   (Temp.t, 'a) Map.t ->
   ((Temp.t, 'a) Map.t, Temp.t Set.t) result

--- a/lib/backend/vasm.ml
+++ b/lib/backend/vasm.ml
@@ -12,7 +12,6 @@ type jump =
 (* NOTE update equal method when updating this *)
 type instr_desc =
   | Jump of jump
-  | Call
   | Linear
   | Ret
 
@@ -60,10 +59,6 @@ let mk_ret reads writes =
   _mk_instr reads writes Ret
 ;;
 
-let mk_call reads writes =
-  _mk_instr reads writes Call
-;;
-
 
 let get_reads t : Temp.t Set.t =
   match t with
@@ -75,18 +70,6 @@ let get_writes t : Temp.t Set.t =
   match t with
   | Label _     -> Set.empty Temp.compare
   | Instr instr -> instr.writes
-;;
-
-let _is_instr_call instr : bool =
-  match instr.desc with
-  | Call -> true
-  | Linear | Ret | Jump _ -> false
-;;
-
-let is_call t =
-  match t with
-  | Label _ -> false
-  | Instr instr -> _is_instr_call instr
 ;;
 
 
@@ -104,7 +87,6 @@ let _jump_equal (j1 : jump) (j2 : jump) : bool =
 
 let _instr_desc_equal (d1 : instr_desc) (d2 : instr_desc) : bool =
   match d1, d2 with
-  | Call, Call       -> true
   | Linear, Linear   -> true
   | Ret, Ret         -> true
   | Jump j1, Jump j2 -> _jump_equal j1 j2
@@ -267,7 +249,6 @@ let _ctx_handle_instr (ctx : context) (instr : instr) : context =
   let ctx = _ctx_add_instr ctx (Instr instr) in
   match instr.desc with
   | Ret    -> _ctx_handle_ret ctx
-  | Call   -> ctx (* no inter-procedural analysis *)
   | Linear -> ctx (* linear control flow, i.e., straight to next instr *)
   | Jump jump -> _ctx_handle_jump ctx jump
 ;;
@@ -325,7 +306,6 @@ let _pp_instr (instr : instr) : string =
   let desc_str =
     match instr.desc with
     | Linear -> "instr"
-    | Call -> "call"
     | Ret  -> "ret"
     | Jump jump -> _pp_jump jump
   in

--- a/lib/backend/vasm.mli
+++ b/lib/backend/vasm.mli
@@ -11,13 +11,11 @@ val mk_instr     : Temp.t list -> Temp.t list -> t
 val mk_dir_jump  : Temp.t list -> Temp.t list -> Label.t -> t
 val mk_cond_jump : Temp.t list -> Temp.t list -> Label.t -> t
 val mk_ret       : Temp.t list -> Temp.t list -> t
-val mk_call      : Temp.t list -> Temp.t list -> t
 
 
 (* Some query functions over [t] *)
 val get_reads    : t -> Temp.t Set.t
 val get_writes   : t -> Temp.t Set.t
-val is_call      : t -> bool
 
 (** structural equality *)
 val equal : t -> t -> bool

--- a/lib/backend/x86.ml
+++ b/lib/backend/x86.ml
@@ -41,7 +41,7 @@ let _physical_reg_list_to_set (prs : physical_reg list) : physical_reg Set.t =
   List.fold_right Set.add prs (Set.empty _compare_physical_reg)
 ;;
 
-let ordered_argument_physical_regs =
+let _ordered_argument_physical_regs =
   [Rdi; Rsi; Rdx; Rcx; R8; R9]
 ;;
 
@@ -55,12 +55,6 @@ let _callee_saved_physical_regs =
 
 let assignable_regs =
   Set.union _caller_saved_physical_regs _callee_saved_physical_regs
-;;
-
-let rax_physical_reg = Rax
-;;
-
-let rdx_physical_reg = Rdx
 ;;
 
 
@@ -161,7 +155,7 @@ let _init_sp_temps (init_temp_man : Temp.manager) : (Temp.manager * sp_temps) =
     | Some temp -> temp
   in
 
-  let sp_prs = Rax::Rdx::ordered_argument_physical_regs in
+  let sp_prs = Rax::Rdx::_ordered_argument_physical_regs in
   let sp_prs = List.fold_right Set.add sp_prs (Set.empty _compare_physical_reg)
   in
   let sp_prs = Set.union sp_prs _caller_saved_physical_regs in
@@ -171,7 +165,7 @@ let _init_sp_temps (init_temp_man : Temp.manager) : (Temp.manager * sp_temps) =
                  ; ordered_arg_regs =
                      List.map
                        (fun pr -> (get_temp pr_map pr, pr))
-                       ordered_argument_physical_regs
+                       _ordered_argument_physical_regs
                  ; caller_saved =
                      Set.fold
                        (fun map pr -> Map.add (get_temp pr_map pr) pr map)

--- a/lib/backend/x86.ml
+++ b/lib/backend/x86.ml
@@ -45,12 +45,16 @@ let ordered_argument_physical_regs =
   [Rdi; Rsi; Rdx; Rcx; R8; R9]
 ;;
 
-let caller_saved_physical_regs =
+let _caller_saved_physical_regs =
   _physical_reg_list_to_set [Rdi; Rsi; Rdx; Rcx; R8; R9; Rax; R10; R11]
 ;;
 
-let callee_saved_physical_regs =
+let _callee_saved_physical_regs =
   _physical_reg_list_to_set [Rbx; R12; R13; R14; R15]
+;;
+
+let assignable_regs =
+  Set.union _caller_saved_physical_regs _callee_saved_physical_regs
 ;;
 
 let rax_physical_reg = Rax
@@ -160,7 +164,7 @@ let _init_sp_temps (init_temp_man : Temp.manager) : (Temp.manager * sp_temps) =
   let sp_prs = Rax::Rdx::ordered_argument_physical_regs in
   let sp_prs = List.fold_right Set.add sp_prs (Set.empty _compare_physical_reg)
   in
-  let sp_prs = Set.union sp_prs caller_saved_physical_regs in
+  let sp_prs = Set.union sp_prs _caller_saved_physical_regs in
   let temp_man, pr_map = alloc_temp_for_prs init_temp_man sp_prs in
   let sp_temps = { rax = get_temp pr_map Rax
                  ; rdx = get_temp pr_map Rdx
@@ -172,7 +176,7 @@ let _init_sp_temps (init_temp_man : Temp.manager) : (Temp.manager * sp_temps) =
                      Set.fold
                        (fun map pr -> Map.add (get_temp pr_map pr) pr map)
                        (Map.empty Temp.compare)
-                       caller_saved_physical_regs
+                       _caller_saved_physical_regs
                  }
   in (temp_man, sp_temps)
 
@@ -914,7 +918,7 @@ let _get_callee_saved_prs (pr_assignment : (Temp.t, physical_reg) Map.t)
   : physical_reg Set.t =
   Map.fold
     (fun pr callee_saved ->
-       if Set.mem pr callee_saved_physical_regs
+       if Set.mem pr _callee_saved_physical_regs
        then Set.add pr callee_saved
        else callee_saved)
     pr_assignment

--- a/lib/backend/x86.ml
+++ b/lib/backend/x86.ml
@@ -687,6 +687,7 @@ let _get_reads_and_writes_temp_instr sp_temps (instr : Temp.t instr)
     let reads = List.fold_right Set.add reg_arg_temps reads in
     let reads = _add_temps_in_call_target reads target in
     let writes = Set.add sp_temps.rax writes in
+    let writes = Set.union (Map.get_key_set sp_temps.caller_saved) writes in
     (reads, writes)
 
   | Ret ->

--- a/lib/backend/x86.ml
+++ b/lib/backend/x86.ml
@@ -177,7 +177,7 @@ let _init_sp_temps (init_temp_man : Temp.manager) : (Temp.manager * sp_temps) =
   in (temp_man, sp_temps)
 
 let _get_sp_temps_coloring sp_temps : (Temp.t, physical_reg) Map.t =
-  let pre_color = Map.empty Temp.compare in
+  let pre_color = sp_temps.caller_saved in
   let temp_reg_pairs =
     (sp_temps.rax, Rax)::
     (sp_temps.rdx, Rdx)::

--- a/lib/backend/x86.ml
+++ b/lib/backend/x86.ml
@@ -701,10 +701,8 @@ let _temp_instr_to_vasm (sp_temps : sp_temps) (instr : Temp.t instr) : Vasm.t =
   match instr with
   | Label label -> Vasm.mk_label label
 
-  | Load _ | Store _ | Push _ | Pop _ | Binop _ | Cmp _ | IDiv _ ->
+  | Load _ | Store _ | Push _ | Pop _ | Binop _ | Cmp _ | IDiv _ | Call _ ->
     Vasm.mk_instr reads writes
-
-  | Call _ -> Vasm.mk_call reads writes
 
   | Jmp target -> Vasm.mk_dir_jump reads writes target
   | JmpC (_, target) -> Vasm.mk_cond_jump reads writes target

--- a/lib/backend/x86.mli
+++ b/lib/backend/x86.mli
@@ -68,8 +68,7 @@ val temp_func_to_str : temp_func -> string
 val physical_reg_to_str : physical_reg -> string
 
 (* Some pre-defined X86 physical registers *)
-val callee_saved_physical_regs     : physical_reg Set.t
-val caller_saved_physical_regs     : physical_reg Set.t
+val assignable_regs                : physical_reg Set.t
 val ordered_argument_physical_regs : physical_reg list
 val rax_physical_reg               : physical_reg
 val rdx_physical_reg               : physical_reg

--- a/lib/backend/x86.mli
+++ b/lib/backend/x86.mli
@@ -63,12 +63,11 @@ val temp_func_to_func : temp_func -> (Temp.t, physical_reg) Map.t -> func
 (** [prog_to_str prog] outputs a valid X86 assembly text of [prog] *)
 val prog_to_str : prog -> string
 
+
+(* X86 physical registers that can be used in register allocation. *)
+val assignable_regs                : physical_reg Set.t
+
+
 (* For debugging *)
 val temp_func_to_str : temp_func -> string
 val physical_reg_to_str : physical_reg -> string
-
-(* Some pre-defined X86 physical registers *)
-val assignable_regs                : physical_reg Set.t
-val ordered_argument_physical_regs : physical_reg list
-val rax_physical_reg               : physical_reg
-val rdx_physical_reg               : physical_reg

--- a/lib/driver.ml
+++ b/lib/driver.ml
@@ -45,8 +45,7 @@ let rec _x86_temp_func_to_func (temp_func : X86.temp_func) : X86.func =
   let pre_color = X86.get_pre_coloring temp_func in
   match Reg_alloc.greedy_alloc
           annotated_vasms 
-          X86.caller_saved_physical_regs
-          X86.callee_saved_physical_regs
+          X86.assignable_regs
           pre_color with
   | Ok temp_to_reg -> X86.temp_func_to_func temp_func temp_to_reg 
   | Error temps_to_spill ->

--- a/test/soc/backend/reg_alloc_test.ml
+++ b/test/soc/backend/reg_alloc_test.ml
@@ -92,7 +92,6 @@ let _check_coloring_size
 let tests = OUnit2.(>:::) "reg_alloc_test" [
 
     OUnit2.(>::) "test_greedy_alloc_no_precolor" (fun _ ->
-        let empty_regs = _int_set [] in
         let regs = _int_set [0; 1] in
         let pre_colored = Map.empty Temp.compare in
         let manager, t0 = Temp.gen Temp.init_manager in
@@ -107,11 +106,8 @@ let tests = OUnit2.(>:::) "reg_alloc_test" [
               (Vasm.mk_instr [t1; t2] [t0], []);
             ]
         in
-        (* caller/callee saved shouldn't matter for these instrs *)
         _check_coloring [(t0, 1); (t1, 0); (t2, 1)]
-          (Reg_alloc.greedy_alloc instrs regs empty_regs pre_colored);
-        _check_coloring [(t0, 1); (t1, 0); (t2, 1)]
-          (Reg_alloc.greedy_alloc instrs empty_regs regs pre_colored);
+          (Reg_alloc.greedy_alloc instrs regs pre_colored);
 
         (* spill live-in *)
         let manager, t3 = Temp.gen manager in
@@ -129,15 +125,11 @@ let tests = OUnit2.(>:::) "reg_alloc_test" [
               (Vasm.mk_instr [t0; t1] [t0], []);
             ]
         in
-        (* caller/callee saved shouldn't matter for these instrs *)
         _check_spills [t0; t4]
-          (Reg_alloc.greedy_alloc instrs regs empty_regs pre_colored);
-        _check_spills [t0; t4]
-          (Reg_alloc.greedy_alloc instrs empty_regs regs pre_colored);
+          (Reg_alloc.greedy_alloc instrs regs pre_colored);
       );
 
     OUnit2.(>::) "test_greedy_alloc_with_precolor" (fun _ ->
-        let empty_regs = _int_set [] in
         let regs = _int_set [0; 1; 2] in
         let manager, t0 = Temp.gen Temp.init_manager in
         let manager, t1 = Temp.gen manager in
@@ -162,15 +154,10 @@ let tests = OUnit2.(>:::) "reg_alloc_test" [
               (Vasm.mk_instr [t2; t3] [t0], []);
             ]
         in
-        (* caller/callee saved shouldn't matter for these instrs *)
         _check_spills [t3]
-          (Reg_alloc.greedy_alloc instrs regs empty_regs pre_colored);
-        _check_spills [t3]
-          (Reg_alloc.greedy_alloc instrs empty_regs regs pre_colored);
+          (Reg_alloc.greedy_alloc instrs regs pre_colored);
         _check_coloring [(t1, 0); (t2, 1); (t3, 2); (t0, 0)]
-          (Reg_alloc.greedy_alloc instrs regs empty_regs _empty_temp_map);
-        _check_coloring [(t1, 0); (t2, 1); (t3, 2); (t0, 0)]
-          (Reg_alloc.greedy_alloc instrs empty_regs regs _empty_temp_map);
+          (Reg_alloc.greedy_alloc instrs regs _empty_temp_map);
       );
   ]
 

--- a/test/soc/backend/reg_alloc_test.ml
+++ b/test/soc/backend/reg_alloc_test.ml
@@ -91,7 +91,7 @@ let _check_coloring_size
 
 let tests = OUnit2.(>:::) "reg_alloc_test" [
 
-    OUnit2.(>::) "test_greedy_alloc_no_precolor_no_call" (fun _ ->
+    OUnit2.(>::) "test_greedy_alloc_no_precolor" (fun _ ->
         let empty_regs = _int_set [] in
         let regs = _int_set [0; 1] in
         let pre_colored = Map.empty Temp.compare in
@@ -136,7 +136,7 @@ let tests = OUnit2.(>:::) "reg_alloc_test" [
           (Reg_alloc.greedy_alloc instrs empty_regs regs pre_colored);
       );
 
-    OUnit2.(>::) "test_greedy_alloc_with_precolor_no_call" (fun _ ->
+    OUnit2.(>::) "test_greedy_alloc_with_precolor" (fun _ ->
         let empty_regs = _int_set [] in
         let regs = _int_set [0; 1; 2] in
         let manager, t0 = Temp.gen Temp.init_manager in
@@ -171,78 +171,6 @@ let tests = OUnit2.(>:::) "reg_alloc_test" [
           (Reg_alloc.greedy_alloc instrs regs empty_regs _empty_temp_map);
         _check_coloring [(t1, 0); (t2, 1); (t3, 2); (t0, 0)]
           (Reg_alloc.greedy_alloc instrs empty_regs regs _empty_temp_map);
-      );
-
-    OUnit2.(>::) "test_greedy_alloc_no_precolor_has_call" (fun _ ->
-        let callee_saved = _int_set [0; 1; 2] in
-        let caller_saved = _int_set [3] in
-        let pre_colored = Map.empty Temp.compare in
-        let manager, t0 = Temp.gen Temp.init_manager in
-        let manager, t1 = Temp.gen manager in
-        let manager, t2 = Temp.gen manager in
-        let _, t3 = Temp.gen manager in
-        (* ...             # live-out = [T0, T1]
-         * T0 := T0 + T1   # live-out = [T0, T1]
-         * Call (T2, T3)   # live-out = [T0, T1] 
-         * T0 := T0 + T1   # live-out = []
-         * ...
-         *
-         * (T0, T1) must be colored to callee_saved, 
-         * (T2, T3) should be able to utilize the extra callee_saved color *)
-        let instrs = Backend_aux.mk_annotated_vasms [t0; t1;]
-            [
-              (Vasm.mk_instr [t0; t1] [t0], [t0; t1;]);
-              (Vasm.mk_call  [t2; t3] [],   [t0; t1;]);
-              (Vasm.mk_instr [t0; t1] [t0], []);
-            ]
-        in
-        _check_coloring [(t0, 3); (t1, 0); (t2, 1); (t3, 2)]
-          (Reg_alloc.greedy_alloc instrs caller_saved callee_saved pre_colored);
-
-        (* [T0 ~ T3] := _ # live-out = [T0, T1, T2, T3] 
-         * Call           # live-out = [T0, T1, T2, T3] 
-         * [T0 ~ T3]      # live-out = []
-         *
-         * one of [T0 ~ T3] needs to be spilled *)
-        let instrs = Backend_aux.mk_annotated_vasms []
-            [
-              (Vasm.mk_instr [] [t0; t1; t2; t3], [t0; t1; t2; t3]);
-              (Vasm.mk_call  [] [],               [t0; t1; t2; t3]);
-              (Vasm.mk_instr [t0; t1; t2; t3] [], []);
-            ]
-        in
-        (* caller/callee saved shouldn't matter for these instrs *)
-        _check_coloring [(t0, 3); (t1, 0); (t2, 1); (t3, 2)]
-          (Reg_alloc.greedy_alloc instrs caller_saved callee_saved pre_colored);
-      );
-
-    OUnit2.(>::) "test_greedy_alloc_with_precolor_has_call" (fun _ ->
-        let callee_saved = _int_set [0; 1] in
-        let caller_saved = _int_set [2] in
-        let manager, t0 = Temp.gen Temp.init_manager in
-        let _, t1 = Temp.gen manager in
-        let pre_colored = _temp_pairs_to_map [(t1, 2)] in
-        (*             # live-out = []
-         * T0, T1 := _ # live-out = [T0, T1]
-         * Call        # live-out = [T0, T1] 
-         * T0 + T1     # live-out = []
-         * ...
-         *
-         * - w/o pre-coloring, T0 and T1 will take up calle_saved colors,
-         * - with pre-coloring T1 to callee_saved, it must be spilled. *)
-        let instrs = Backend_aux.mk_annotated_vasms []
-            [
-              (Vasm.mk_instr [] [t0; t1], [t0; t1]);
-              (Vasm.mk_call  [] [],       [t0; t1]);
-              (Vasm.mk_instr [t0; t1] [], []);
-            ]
-        in
-        _check_coloring [(t0, 2); (t1, 0)]
-          (Reg_alloc.greedy_alloc
-             instrs caller_saved callee_saved _empty_temp_map);
-        _check_spills [t0]
-          (Reg_alloc.greedy_alloc
-             instrs caller_saved callee_saved pre_colored);
       );
   ]
 

--- a/test/soc/backend/reg_alloc_test.ml
+++ b/test/soc/backend/reg_alloc_test.ml
@@ -196,7 +196,7 @@ let tests = OUnit2.(>:::) "reg_alloc_test" [
               (Vasm.mk_instr [t0; t1] [t0], []);
             ]
         in
-        _check_coloring [(t0, 1); (t1, 0); (t2, 3); (t3, 2)]
+        _check_coloring [(t0, 3); (t1, 0); (t2, 1); (t3, 2)]
           (Reg_alloc.greedy_alloc instrs caller_saved callee_saved pre_colored);
 
         (* [T0 ~ T3] := _ # live-out = [T0, T1, T2, T3] 
@@ -212,7 +212,7 @@ let tests = OUnit2.(>:::) "reg_alloc_test" [
             ]
         in
         (* caller/callee saved shouldn't matter for these instrs *)
-        _check_spills [t0]
+        _check_coloring [(t0, 3); (t1, 0); (t2, 1); (t3, 2)]
           (Reg_alloc.greedy_alloc instrs caller_saved callee_saved pre_colored);
       );
 
@@ -237,10 +237,10 @@ let tests = OUnit2.(>:::) "reg_alloc_test" [
               (Vasm.mk_instr [t0; t1] [], []);
             ]
         in
-        _check_coloring [(t0, 1); (t1, 0)]
+        _check_coloring [(t0, 2); (t1, 0)]
           (Reg_alloc.greedy_alloc
              instrs caller_saved callee_saved _empty_temp_map);
-        _check_spills [t1]
+        _check_spills [t0]
           (Reg_alloc.greedy_alloc
              instrs caller_saved callee_saved pre_colored);
       );


### PR DESCRIPTION
Context: #45

Register allocator doesn't need to know about caller/callee-saved regs and call instruction.

Think about what a call instruction does (ignoring the control flow and operations in callee)
- reads from argument registers
- _might_ write to RAX and caller-saved registers

If we encode that in Vasm, register allocator automatically ensures that temps that live across a call instruction must be spilled or assigned to callee-saved regs, because caller-saved regs are written to in the call instruction (it will force spilling or any temp assigned to caller-saved reg).

This enables a much cleaner design.