### PR TITLE
Add infix ops to pervasives

### DIFF
--- a/bin/soc.ml
+++ b/bin/soc.ml
@@ -7,7 +7,7 @@ let () =
     let x86_prog = Driver.lir_to_x86 lir_prog in
     let x86_prog_str = X86.func_prog_to_str x86_prog in
     let extless_filename, _ = Filename.split_extension filename in
-    let output_filename = String.append extless_filename ".s" in
+    let output_filename = extless_filename ^ ".s" in
     Io.write_file output_filename x86_prog_str
 
   | Error msg -> Io.println msg

--- a/lib/backend/analysis/reg_alloc.ml
+++ b/lib/backend/analysis/reg_alloc.ml
@@ -91,15 +91,13 @@ let _ctx_remove_dead_temps (ctx : 'a context) (killed : Temp.t Set.t)
     List.fold_left
       (fun avalb_colors killed_temp ->
          match Map.get killed_temp ctx.coloring with
+         | Some color -> Set.add color avalb_colors
          | None ->
            if Set.mem killed_temp ctx.temps_to_spill then avalb_colors
-           else
-             failwith 
-               (String.concat
-                  ["[Reg_alloc._ctx_remove_killed_temps] Unspilled killed Temp "
-                  ; (Temp.to_string killed_temp); " should've been colored";])
-         | Some color ->
-           Set.add color avalb_colors)
+           else failwith @@
+             String.concat
+               ["[Reg_alloc._ctx_remove_killed_temps] Unspilled killed Temp "
+               ; (Temp.to_string killed_temp); " should've been colored";])
       ctx.avalb_colors (Set.to_list killed)
   in
   { ctx with temps_in_use; avalb_colors }

--- a/lib/backend/analysis/reg_alloc.ml
+++ b/lib/backend/analysis/reg_alloc.ml
@@ -94,10 +94,9 @@ let _ctx_remove_dead_temps (ctx : 'a context) (killed : Temp.t Set.t)
          | Some color -> Set.add color avalb_colors
          | None ->
            if Set.mem killed_temp ctx.temps_to_spill then avalb_colors
-           else failwith @@
-             String.concat
-               ["[Reg_alloc._ctx_remove_killed_temps] Unspilled killed Temp "
-               ; (Temp.to_string killed_temp); " should've been colored";])
+           else failwith
+               ("[Reg_alloc._ctx_remove_killed_temps] Unspilled killed Temp " ^
+                (Temp.to_string killed_temp) ^ " should've been colored"))
       ctx.avalb_colors (Set.to_list killed)
   in
   { ctx with temps_in_use; avalb_colors }

--- a/lib/backend/analysis/vasm.ml
+++ b/lib/backend/analysis/vasm.ml
@@ -299,7 +299,7 @@ let _pp_jump (jump : jump) : string =
     | Conditional -> "conditional"
     | Unconditional -> "unconditional"
   in
-  String.concat [kind_str; " jump to "; Label.to_string jump.target]
+  kind_str ^ " jump to " ^ Label.to_string jump.target
 ;;
 
 let _pp_instr (instr : instr) : string =
@@ -310,9 +310,8 @@ let _pp_instr (instr : instr) : string =
     | Jump jump -> _pp_jump jump
   in
   let rw_str =
-    String.concat
-      [", reads = "; Set.to_string Temp.to_string instr.reads;
-       ", writes = "; Set.to_string Temp.to_string instr.writes;]
+    ", reads = " ^ Set.to_string Temp.to_string instr.reads ^
+    ", writes = " ^ Set.to_string Temp.to_string instr.writes
   in
   desc_str ^ rw_str
 ;;

--- a/lib/backend/analysis/vasm.ml
+++ b/lib/backend/analysis/vasm.ml
@@ -314,7 +314,7 @@ let _pp_instr (instr : instr) : string =
       [", reads = "; Set.to_string Temp.to_string instr.reads;
        ", writes = "; Set.to_string Temp.to_string instr.writes;]
   in
-  String.append desc_str rw_str
+  desc_str ^ rw_str
 ;;
 
 let pp t =

--- a/lib/backend/cir.ml
+++ b/lib/backend/cir.ml
@@ -272,7 +272,7 @@ and _partial_apply (ctx : context)
     _gen_new_var_names ctx "extra_arg" extra_args_needed
   in
   let provided_arg_names = List.map (fun (var, _) -> var) provided_arg_bds in
-  let all_arg_names = List.append provided_arg_names extra_arg_names in
+  let all_arg_names = provided_arg_names @ extra_arg_names in
   let cls_body = Capply (Cident func_bind_name,
                          List.map (fun name -> Cident name) all_arg_names) in
   let free_var_names = func_bind_name::provided_arg_names in
@@ -385,7 +385,7 @@ let from_ast_struct structure =
    * _nicely_ without introducing external syntax. *)
   let ctx, primop_bds = _add_primops_closures ctx in
   let ctx, native_bds = _add_natives_closures ctx in
-  let builtin_bds = List.append primop_bds native_bds in
+  let builtin_bds = primop_bds @ native_bds in
   { closures = _get_all_closures ctx
   ; expr = Clet (builtin_bds, final_ce)
   }

--- a/lib/backend/common/graph.ml
+++ b/lib/backend/common/graph.ml
@@ -27,7 +27,7 @@ let empty_graph () =
 let _get_node_info (t : 'a t) (n : node) (func : string) : 'a node_info =
   match Map.get n t.node_infos with
   | None ->
-    failwith (String.concat ["[Graph."; func; "] node not bound in graph"])
+    failwith ("[Graph." ^ func ^ "] node not bound in graph")
   | Some info -> info
 ;;
 

--- a/lib/backend/common/label.ml
+++ b/lib/backend/common/label.ml
@@ -15,7 +15,7 @@ let to_string t = String.join_with [t.name; t.suffix] "_"
 ;;
 
 let _add_suffix t (extra : string) : t =
-  let suffix = String.append t.suffix extra in
+  let suffix = t.suffix ^ extra in
   { t with suffix }
 ;;
 
@@ -33,7 +33,7 @@ let is_native t =
 ;;
 
 let to_epilogue t =
-  let suffix = String.append t.suffix "_epilogue" in
+  let suffix = t.suffix ^ "_epilogue" in
   { t with suffix } (* disjoint from other [t] *)
 ;;
 

--- a/lib/backend/common/temp.ml
+++ b/lib/backend/common/temp.ml
@@ -39,7 +39,7 @@ let get manager s =
 ;;
 
 let to_string t =
-  String.append "T" (Int.to_string t)
+  "T" ^ (Int.to_string t)
 ;;
 
 let compare = Int.compare

--- a/lib/backend/lir.ml
+++ b/lib/backend/lir.ml
@@ -235,8 +235,8 @@ and _transl_binop_with_short_circuit
     (value : expr) (prefix : string)
   : (context * expr) =
   let ctx, short_circuit_label =
-    _ctx_gen_label ctx (String.append prefix "_short_circuit") in
-  let ctx, end_label = _ctx_gen_label ctx (String.append prefix "_end") in
+    _ctx_gen_label ctx (prefix ^ "_short_circuit") in
+  let ctx, end_label = _ctx_gen_label ctx (prefix ^ "_end") in
   let ctx, result_temp = _ctx_gen_temp ctx in
   let lhs_eq_value_e = Equal (lhs_e, value) in
   let ctx = _ctx_add_instr ctx (Jump (lhs_eq_value_e, short_circuit_label)) in

--- a/lib/backend/x86.ml
+++ b/lib/backend/x86.ml
@@ -1010,7 +1010,7 @@ let _reg_offset_to_str
     else " + ", offset
   in
   let offset_str = Int.to_string offset in
-  String.concat ["["; reg_str; op_str; offset_str ; "]"]
+  "[" ^ reg_str ^ op_str ^ offset_str  ^ "]"
 ;;
 
 let _arg_to_str (arg : 'a arg) (gr_to_str : 'a -> string) : string =
@@ -1049,41 +1049,41 @@ let _instr_to_str (instr : 'a instr) (gr_to_str : 'a -> string) : string =
   | Load (arg, dst_reg) ->
     let arg_str = _arg_to_str arg gr_to_str in
     let dst_str = _reg_to_str dst_reg gr_to_str in
-    let instr_str = String.concat ["mov "; dst_str; ", "; arg_str;] in
+    let instr_str = "mov " ^ dst_str ^ ", " ^ arg_str in
     add_tab instr_str
 
   | Store (src_reg, dst_addr_reg, offset) ->
     let src_str = _reg_to_str src_reg gr_to_str in
     let dst_str = _reg_offset_to_str dst_addr_reg offset gr_to_str in
-    let instr_str = String.concat ["mov "; dst_str; ", "; src_str;] in
+    let instr_str = "mov " ^ dst_str ^ ", " ^ src_str in
     add_tab instr_str
 
   | Push reg ->
     let reg_str = _reg_to_str reg gr_to_str in
-    let instr_str = String.concat ["push"; " "; reg_str] in
+    let instr_str = "push" ^ " " ^ reg_str in
     add_tab instr_str
 
   | Pop reg ->
     let reg_str = _reg_to_str reg gr_to_str in
-    let instr_str = String.concat ["pop"; " "; reg_str] in
+    let instr_str = "pop" ^ " " ^ reg_str in
     add_tab instr_str
 
   | IDiv reg ->
     let reg_str = _reg_to_str reg gr_to_str in
-    let instr_str = String.concat ["idiv"; " "; reg_str] in
+    let instr_str = "idiv" ^ " " ^ reg_str in
     add_tab instr_str
 
   | Binop (binop, reg, arg) ->
     let arg_str = _arg_to_str arg gr_to_str in
     let reg_str = _reg_to_str reg gr_to_str in
     let binop_str = _binop_to_str binop in
-    let instr_str = String.concat [binop_str; " "; reg_str; ", "; arg_str;] in
+    let instr_str = binop_str ^ " " ^ reg_str ^ ", " ^ arg_str in
     add_tab instr_str
 
   | Cmp (arg, gr) ->
     let arg_str = _arg_to_str arg gr_to_str in
     let gr_str = gr_to_str gr in
-    let instr_str = String.concat ["cmp "; arg_str; ", "; gr_str;] in
+    let instr_str = "cmp " ^ arg_str ^ ", " ^ gr_str in
     add_tab instr_str
 
   | Jmp label ->
@@ -1093,12 +1093,12 @@ let _instr_to_str (instr : 'a instr) (gr_to_str : 'a -> string) : string =
   | JmpC (cond, label) ->
     let suffix = _cond_to_suffix cond in
     let label_str = Label.to_string label in
-    let instr_str = String.concat ["j"; suffix; " "; label_str] in
+    let instr_str = "j" ^ suffix ^ " " ^ label_str in
     add_tab instr_str
 
   | Call (target, _) -> (* args are used for liveness analysis or debugging *)
     let target_str = _call_target_to_str target gr_to_str in
-    let instr_str = String.concat ["call"; " "; target_str] in
+    let instr_str = "call" ^ " " ^ target_str in
     add_tab instr_str
 
   | Ret -> add_tab "ret"

--- a/lib/backend/x86.ml
+++ b/lib/backend/x86.ml
@@ -1042,9 +1042,9 @@ let _call_target_to_str (target : 'a call_target) (gr_to_str : 'a -> string)
 ;;
 
 let _instr_to_str (instr : 'a instr) (gr_to_str : 'a -> string) : string =
-  let add_tab s = String.append "\t" s in
+  let add_tab s = "\t" ^ s in
   match instr with
-  | Label label -> String.append (Label.to_string label) ":"
+  | Label label -> (Label.to_string label) ^ ":"
 
   | Load (arg, dst_reg) ->
     let arg_str = _arg_to_str arg gr_to_str in
@@ -1087,7 +1087,7 @@ let _instr_to_str (instr : 'a instr) (gr_to_str : 'a -> string) : string =
     add_tab instr_str
 
   | Jmp label ->
-    let instr_str = String.append "jmp " (Label.to_string label)in
+    let instr_str = "jmp " ^ (Label.to_string label)in
     add_tab instr_str
 
   | JmpC (cond, label) ->
@@ -1169,11 +1169,11 @@ let _find_external_native_labels_in_prog (prog : func prog) : Label.t Set.t =
 let _get_prog_metadata (prog : func prog) : string =
   let external_native_label_decls = 
     List.map
-      (fun label -> String.append "extern " (Label.to_string label))
+      (fun label -> "extern " ^ (Label.to_string label))
       (Set.to_list (_find_external_native_labels_in_prog prog))
   in
   let global_native_label_decls =
-    [String.append "global " (Label.to_string prog.main.entry)]
+    ["global " ^ (Label.to_string prog.main.entry)]
   in
   let metadata_lines =
       ("section .text"::external_native_label_decls) @

--- a/lib/common/namer.ml
+++ b/lib/common/namer.ml
@@ -12,7 +12,7 @@ let init default_prefix =
 ;;
 
 let gen_new_name_with_prefix t prefix =
-  let name = String.concat [prefix; "_"; Int.to_string t.stamp] in
+  let name = prefix ^ "_" ^ (Int.to_string t.stamp) in
   let t = { t with stamp = t.stamp + 1 } in
   (t, name)
 ;;

--- a/lib/common/pretty.ml
+++ b/lib/common/pretty.ml
@@ -23,7 +23,7 @@ let _dec_space (p : printer) (n : int) : unit =
 ;;
 
 let __print_str_only (p : printer) (s : string) : unit =
-  p.buffer <- String.append p.buffer s
+  p.buffer <- p.buffer ^ s
 ;;
 
 (* [endline] specifies whether a newline will be printed to end current line *)
@@ -176,7 +176,7 @@ let pp_ast_interp_error (err : Errors.ast_interp_error) =
         " but got "; (Int.to_string actual); " at "; (_pp_span span); ]
 
   | Ast_interp_letrec_invalid_rhs span ->
-    String.append "Invalid rhs of let rec binding at " (_pp_span span)
+    "Invalid rhs of let rec binding at " ^ (_pp_span span)
 ;;
 
 
@@ -364,7 +364,7 @@ let pp_typer_error (err : Errors.typer_error) =
         " but got <"; (pp_ast_typ actual); "> at "; (_pp_span span); ]
 
   | Typer_illegal_letrec_rhs span ->
-    String.append "[Typer]: Illegal rhs of let rec binding at " (_pp_span span)
+    "[Typer]: Illegal rhs of let rec binding at " ^ (_pp_span span)
 
   | Typer_tyvar_occurs (expect, actual, actual_span, tv_name, occurree) ->
     String.concat
@@ -372,7 +372,6 @@ let pp_typer_error (err : Errors.typer_error) =
         " but got <"; (pp_ast_typ actual); "> at "; (_pp_span actual_span);
         ". The type variable '"; tv_name;
         " occurs within "; (pp_ast_typ occurree) ]
-
 ;;
 
 

--- a/lib/common/pretty.ml
+++ b/lib/common/pretty.ml
@@ -64,27 +64,23 @@ let _print_newline (p : printer) : unit =
 let pp_lexer_error (err : Errors.lexer_error) : string =
   match err with
   | Lexer_unexpected_char (expect, actual, loc) ->
-    String.concat
-      [ "[Lexer] Expected '"; (Char.to_string expect);
-        "', but got '"; (Char.to_string actual); "'";
-        " at "; (Location.to_string loc); ]
+    "[Lexer] Expected '" ^ (Char.to_string expect) ^ "', but got '" ^
+    (Char.to_string actual) ^ "'" ^ " at " ^ (Location.to_string loc)
 
   | Lexer_unexpected_eof (where, expected) ->
-    String.concat
-      [ "[Lexer] Unexpected EOF while expecting "; (Char.to_string expected);
-        " at "; (Location.to_string where); ]
+    "[Lexer] Unexpected EOF while expecting " ^ (Char.to_string expected) ^
+    " at " ^ (Location.to_string where)
 
   | Lexer_invalid_start (start, loc) ->
-    String.concat
-      [ "[Lexer] Invalid start of token: '"; (Char.to_string start);
-        "' at "; (Location.to_string loc); ]
+    "[Lexer] Invalid start of token: '" ^ (Char.to_string start) ^
+    "' at " ^ (Location.to_string loc)
 ;;
 
 
 let _pp_span (span : Span.t) : string =
-  String.concat
-    [ "<"; (Location.to_string span.start); "-";
-      (Location.to_string span.final); ">" ]
+  "<" ^ 
+  (Location.to_string span.start) ^ "-" ^ (Location.to_string span.final) ^
+  ">"
 ;;
 
 (* Whether to show content of [Token.Int], etc. *)
@@ -95,8 +91,8 @@ type token_desc_visibility =
 let _pp_token_desc_impl desc (visibility : token_desc_visibility) =
   let pp_tok_with_content (tok : string) (content : string) =
     match visibility with
-    | Hide_content -> String.concat ["<"; tok; ">"]
-    | Show_content -> String.concat ["<"; tok; " ("; content; ")>"]
+    | Hide_content -> "<" ^ tok ^ ">"
+    | Show_content -> "<" ^ tok ^ " (" ^ content ^ ")>"
   in
   match desc with
   | Token.AmperAmper -> "<AmperAmper>"
@@ -132,9 +128,9 @@ let pp_token_desc desc =
 ;;
 
 let pp_token (tok : Token.t) =
-  String.concat
-    [ "{"; (pp_token_desc tok.token_desc);
-      " at "; (_pp_span tok.token_span); "}"; ]
+  "{" ^
+  (pp_token_desc tok.token_desc) ^ " at " ^ (_pp_span tok.token_span) ^
+  "}"
 ;;
 
 let pp_parser_error (err : Errors.parser_error) =
@@ -145,35 +141,29 @@ let pp_parser_error (err : Errors.parser_error) =
   in
   match err with
   | Parser_invalid_integer (text, span) ->
-    String.concat
-      [ "[Parser]: Invalid integer token <"; text; "> at "; (_pp_span span); ]
+    "[Parser]: Invalid integer token <" ^ text ^ "> at " ^ (_pp_span span)
 
   | Parser_unexpected_token (actual, expects) ->
-    String.concat
-      [ "[Parser]: Unexpected token "; (pp_token actual);
-        " where expected tokens are "; (pp_expected_tokens expects); ]
+    "[Parser]: Unexpected token " ^ (pp_token actual) ^
+    " where expected tokens are " ^ (pp_expected_tokens expects)
 
   | Parser_unexpected_eof (eof_loc, expects) ->
-    String.concat
-      [ "[Parser]: Unexpected EOF at "; (Location.to_string eof_loc);
-        " where expected tokens are "; (pp_expected_tokens expects); ]
+    "[Parser]: Unexpected EOF at " ^ (Location.to_string eof_loc) ^
+    " where expected tokens are " ^ (pp_expected_tokens expects)
 ;;
 
 let pp_ast_interp_error (err : Errors.ast_interp_error) =
   match err with
   | Ast_interp_unbound_var (name, span) ->
-    String.concat
-      [ "[Ast_interp]: Unbound variable <"; name; "> at "; (_pp_span span); ]
+    "[Ast_interp]: Unbound variable <" ^ name ^ "> at " ^ (_pp_span span)
 
   | Ast_interp_type_mismatch (expect, actual, span) ->
-    String.concat
-      [ "[Ast_interp]: Expected type <"; expect; ">";
-        " but got <"; actual; "> at "; (_pp_span span); ]
+    "[Ast_interp]: Expected type <" ^ expect ^ ">" ^
+    " but got <" ^ actual ^ "> at " ^ (_pp_span span)
 
   | Ast_interp_arity_mismatch (expect, actual, span) ->
-    String.concat
-      [ "[Ast_interp]: Expected arity "; (Int.to_string expect);
-        " but got "; (Int.to_string actual); " at "; (_pp_span span); ]
+    "[Ast_interp]: Expected arity " ^ (Int.to_string expect) ^
+    " but got " ^ (Int.to_string actual) ^ " at " ^ (_pp_span span)
 
   | Ast_interp_letrec_invalid_rhs span ->
     "Invalid rhs of let rec binding at " ^ (_pp_span span)
@@ -355,23 +345,19 @@ let pp_ast_expr_with_typ_annot (expr : Ast.expression) =
 let pp_typer_error (err : Errors.typer_error) =
   match err with
   | Typer_unbound_var (name, span) ->
-    String.concat
-      [ "[Typer]: Unbound variable <"; name; "> at "; (_pp_span span); ]
+    "[Typer]: Unbound variable <" ^ name ^ "> at " ^ (_pp_span span)
 
   | Typer_type_mismatch (expect, actual, span) ->
-    String.concat
-      [ "[Typer]: Expected type <"; (pp_ast_typ expect); ">";
-        " but got <"; (pp_ast_typ actual); "> at "; (_pp_span span); ]
+    "[Typer]: Expected type <" ^ (pp_ast_typ expect) ^ ">" ^
+    " but got <" ^ (pp_ast_typ actual) ^ "> at " ^ (_pp_span span)
 
   | Typer_illegal_letrec_rhs span ->
     "[Typer]: Illegal rhs of let rec binding at " ^ (_pp_span span)
 
   | Typer_tyvar_occurs (expect, actual, actual_span, tv_name, occurree) ->
-    String.concat
-      [ "[Typer]: Expected type <"; (pp_ast_typ expect); ">";
-        " but got <"; (pp_ast_typ actual); "> at "; (_pp_span actual_span);
-        ". The type variable '"; tv_name;
-        " occurs within "; (pp_ast_typ occurree) ]
+    "[Typer]: Expected type <" ^ (pp_ast_typ expect) ^ ">" ^
+    " but got <" ^ (pp_ast_typ actual) ^ "> at " ^ (_pp_span actual_span) ^
+    ". The type variable '" ^ tv_name ^ " occurs within " ^ (pp_ast_typ occurree) 
 ;;
 
 

--- a/lib/frontend/interp/ast_interp.ml
+++ b/lib/frontend/interp/ast_interp.ml
@@ -311,8 +311,7 @@ and _partial_apply (original_ctx : context)
   if extra_args_needed <= 0
   then failwith "[Ast_interp._partial_apply] application already has enough args";
   let provided_arg_names =
-    List.init provided_args_num
-      (fun n -> String.append "provided_" (Int.to_string n))
+    List.init provided_args_num (fun n -> "provided_" ^ (Int.to_string n))
   in
   let ctx_with_provided_args =
     List.fold_left (* evalaute left to right, my choice *)
@@ -325,8 +324,7 @@ and _partial_apply (original_ctx : context)
   let ctx_with_everything =
     _context_insert ctx_with_provided_args func_name func_desc in
   let extra_arg_names = 
-    List.init extra_args_needed
-      (fun n -> String.append "extra_" (Int.to_string n))
+    List.init extra_args_needed (fun n -> "extra_" ^ (Int.to_string n))
   in
   let make_dummy_expr (expr_desc : Ast.expr_desc) : Ast.expression =
     { Ast.expr_desc (* NOTE I don't think the span info will be used, ba. *)

--- a/lib/frontend/interp/ast_interp.ml
+++ b/lib/frontend/interp/ast_interp.ml
@@ -336,7 +336,7 @@ and _partial_apply (original_ctx : context)
   let func_ident_e = make_dummy_expr (Exp_ident func_name) in
   let arg_ident_es = List.map
       (fun arg_name -> make_dummy_expr (Exp_ident arg_name))
-      (List.append provided_arg_names extra_arg_names)
+      (provided_arg_names @ extra_arg_names)
   in
   let body_e = make_dummy_expr (Exp_apply (func_ident_e, arg_ident_es)) in
   Closure(extra_arg_names, body_e, ref ctx_with_everything)

--- a/lib/frontend/location.ml
+++ b/lib/frontend/location.ml
@@ -11,7 +11,7 @@ let create row col =
 
 let to_string t =
   let row_str, col_str = Int.to_string t.row, Int.to_string t.col in
-  String.concat ["("; row_str; ", "; col_str; ")"]
+  "(" ^ row_str ^ ", " ^ col_str ^ ")"
 ;;
 
 let advance t =

--- a/lib/frontend/parsing/parser.ml
+++ b/lib/frontend/parsing/parser.ml
@@ -426,7 +426,7 @@ and _parse_expr_or_infix (* possibily with type annotation *)
 and _parse_constant_or_var
     (s : _tok_stream) : Ast.expression =
   let parse_int_expr (str : string) (where : Span.t) : Ast.expression =
-    match Int.of_string_opt str with
+    match int_of_string_opt str with
     | None -> _error_invalid_int str where
     | Some n -> { Ast.expr_desc = Exp_const (Const_Int n);
                   expr_span = where; expr_typ = None }

--- a/lib/frontend/typing/typer.ml
+++ b/lib/frontend/typing/typer.ml
@@ -6,11 +6,10 @@ type 'a ret = (Typer_ctx.t * Ast.typ * 'a)
 
 let _get_annotated_typ (otv : Ast.opt_typed_var) : Ast.typ =
   match otv.typ with
-  | None ->  
-    let msg = "[Typer._get_annotated_typ]" in
-    let msg = String.append msg " all variables should have type annotations" in
-    failwith msg
   | Some typ -> typ
+  | None ->  
+    failwith
+      "[Typer._get_annotated_typ] all variables should have type annotations"
 ;;
 
 

--- a/lib/stdlib/externals.ml
+++ b/lib/stdlib/externals.ml
@@ -43,10 +43,7 @@ let char_to_string = Stdlib.Char.escaped
 let int_to_string = Stdlib.string_of_int
 ;;
 
-let int_of_string_opt s =
-  match Stdlib.int_of_string_opt s with
-  | None -> Pervasives.None
-  | Some n -> Pervasives.Some n
+let int_of_string = Stdlib.int_of_string
 ;;
 
 let string_length = Stdlib.String.length

--- a/lib/stdlib/int.ml
+++ b/lib/stdlib/int.ml
@@ -25,6 +25,3 @@ let compare n1 n2 =
 
 let to_string = Externals.int_to_string
 ;;
-
-let of_string_opt = Externals.int_of_string_opt
-;;

--- a/lib/stdlib/int.mli
+++ b/lib/stdlib/int.mli
@@ -1,4 +1,3 @@
-open Pervasives
 
 (** [max n1 n2] returns the larger of [n1] and [n2] *)
 val max : int -> int -> int
@@ -23,7 +22,3 @@ val compare : int -> int -> int
 
 (** [to_string n] returns a string representation of [n] *)
 val to_string : int -> string
-
-(** [of_string_opt s] returns an integer representation of [s],
-    or [None] if [s] doesn't represent a valid integer *)
-val of_string_opt : string -> int option

--- a/lib/stdlib/list.ml
+++ b/lib/stdlib/list.ml
@@ -23,12 +23,8 @@ let rev xs =
   fold_left (fun reved x -> x::reved) [] xs
 ;;
 
-let append xs ys =
-  fold_right cons xs ys
-;;
-
 let concat xss =
-  fold_right append xss []
+  fold_right (@) xss []
 ;;
 
 let flatten = concat

--- a/lib/stdlib/list.ml
+++ b/lib/stdlib/list.ml
@@ -152,5 +152,5 @@ let init size f =
 let to_string xs f =
   let elem_strs = map f xs in
   let elems_str = String.join_with elem_strs "; " in
-  String.concat ["["; elems_str; "]"]
+  "[" ^ elems_str ^ "]"
 ;;

--- a/lib/stdlib/list.mli
+++ b/lib/stdlib/list.mli
@@ -9,9 +9,6 @@ val length : 'a list -> int
 (** [rev xs] returns a reversed version of [xs] *)
 val rev : 'a list -> 'a list
 
-(** [append xs ys] returns a list with elements of [xs] added to [ys] in order *)
-val append : 'a list -> 'a list -> 'a list
-
 (** [flatten xs] returns a list with the inner lists appended in order *)
 val concat : 'a list list -> 'a list
 

--- a/lib/stdlib/map.ml
+++ b/lib/stdlib/map.ml
@@ -78,7 +78,7 @@ let foldi f t acc =
 
 let to_string f g t =
   let pair_to_str (k, v) =
-    String.concat ["("; (f k); ", "; (g v); ")"]
+    "(" ^ (f k) ^ ", " ^ (g v) ^ ")"
   in
   let pairs = List.map pair_to_str (_unique_pairs t) in
   let inner = String.join_with pairs "; " in

--- a/lib/stdlib/map.ml
+++ b/lib/stdlib/map.ml
@@ -82,7 +82,7 @@ let to_string f g t =
   in
   let pairs = List.map pair_to_str (_unique_pairs t) in
   let inner = String.join_with pairs "; " in
-  String.append "{" (String.append inner "}")
+  "{" ^ inner ^ "}"
 ;;
 
 let get_key_set t =

--- a/lib/stdlib/pervasives.ml
+++ b/lib/stdlib/pervasives.ml
@@ -33,3 +33,7 @@ let rec (@) xs ys =
   | [] -> ys
   | x::xs -> x::(xs @ ys)
 ;;
+
+let (^) =
+  Externals.string_append
+;;

--- a/lib/stdlib/pervasives.ml
+++ b/lib/stdlib/pervasives.ml
@@ -14,3 +14,17 @@ type ('a, 'e) result =
 let not b =
   if b then false else true
 ;;
+
+let (|>) a f =
+  f a
+;;
+
+let (@@) f a =
+  f a
+;;
+
+let rec (@) xs ys =
+  match xs with
+  | [] -> ys
+  | x::xs -> x::(xs @ ys)
+;;

--- a/lib/stdlib/pervasives.ml
+++ b/lib/stdlib/pervasives.ml
@@ -15,6 +15,11 @@ let not b =
   if b then false else true
 ;;
 
+let int_of_string_opt s =
+  try Some (Externals.int_of_string s)
+  with Failure _ -> None
+;;
+
 let (|>) a f =
   f a
 ;;

--- a/lib/stdlib/pervasives.mli
+++ b/lib/stdlib/pervasives.mli
@@ -22,3 +22,12 @@ type ('a, 'e) result =
   | Error of 'e
 
 val not : bool -> bool
+
+(** Pipelining *)
+val (|>) : 'a -> ('a -> 'b) -> 'b
+
+(** Application *)
+val (@@) : ('a -> 'b) -> 'a -> 'b
+
+(** List append *)
+val (@)  : 'a list -> 'a list -> 'a list

--- a/lib/stdlib/pervasives.mli
+++ b/lib/stdlib/pervasives.mli
@@ -23,6 +23,10 @@ type ('a, 'e) result =
 
 val not : bool -> bool
 
+(** [int_of_string_opt s] returns either an integer which [s] represents, or
+    [None] if [s] isn't a valid int *)
+val int_of_string_opt : string -> int option
+
 (** Pipelining *)
 val (|>) : 'a -> ('a -> 'b) -> 'b
 

--- a/lib/stdlib/pervasives.mli
+++ b/lib/stdlib/pervasives.mli
@@ -29,5 +29,6 @@ val (|>) : 'a -> ('a -> 'b) -> 'b
 (** Application *)
 val (@@) : ('a -> 'b) -> 'a -> 'b
 
-(** List append *)
+(** [xs @ ys] is a list with elements of [xs] added to the front of [ys] in
+    order *)
 val (@)  : 'a list -> 'a list -> 'a list

--- a/lib/stdlib/pervasives.mli
+++ b/lib/stdlib/pervasives.mli
@@ -36,3 +36,6 @@ val (@@) : ('a -> 'b) -> 'a -> 'b
 (** [xs @ ys] is a list with elements of [xs] added to the front of [ys] in
     order *)
 val (@)  : 'a list -> 'a list -> 'a list
+
+(** [s1 ^ s2] is a string with [s1] and [s2] appended together *)
+val (^) : string -> string -> string

--- a/lib/stdlib/set.ml
+++ b/lib/stdlib/set.ml
@@ -68,7 +68,7 @@ let fold f acc t =
 ;;
 
 let union t1 t2 =
-  let rep = List.append t1.rep t2.rep in
+  let rep = t1.rep @ t2.rep in
   { t1 with rep }
 ;;
 

--- a/lib/stdlib/set.ml
+++ b/lib/stdlib/set.ml
@@ -97,7 +97,7 @@ let to_list t =
 let to_string f t =
   let es = List.map f (_unique_elems t) in
   let inner = String.join_with es "; " in
-  String.append "{" (String.append inner "}")
+  "{" ^ inner ^ "}"
 ;;
 
 let get_compare_func t =

--- a/lib/stdlib/string.ml
+++ b/lib/stdlib/string.ml
@@ -38,7 +38,3 @@ let join_with init_ss sep =
         go acc ss
     in go fst_s rst_ss
 ;;
-
-let concat ss =
-  join_with ss ""
-;;

--- a/lib/stdlib/string.mli
+++ b/lib/stdlib/string.mli
@@ -16,6 +16,3 @@ val compare : string -> string -> int
 (** [join_with [s1; ...; sn] sep] is [s1 ^ sep ^ ... ^ sep ^ sn] where [^]
     stands for the append operation *)
 val join_with : string list -> string -> string
-
-(** [concat ss] = [join_with ss ""] *)
-val concat : string list -> string

--- a/lib/stdlib/string.mli
+++ b/lib/stdlib/string.mli
@@ -10,9 +10,6 @@ val get : string -> int -> char
 (** [sub s start end] returns the substring from [start] to _before_ [end] *)
 val sub : string -> int -> int -> string
 
-(** [append s1 s2] returns a new string with [s1] and [s2] appended together *)
-val append : string -> string -> string
-
 (** [compare s1 s2] compares 2 strings lexicalgraphically *)
 val compare : string -> string -> int
 

--- a/test/soc/backend/analysis/reg_alloc_test.ml
+++ b/test/soc/backend/analysis/reg_alloc_test.ml
@@ -14,14 +14,12 @@ let _temp_pairs_to_map (pairs : (Temp.t * 'v) list) : (Temp.t, 'v) Map.t =
 
 let _err_unexpected_spill (spills : Temp.t Set.t) : 'a =
   let str = Set.to_string Temp.to_string spills in
-  let msg = String.append "Unexpected spill: " str in
-  OUnit2.assert_failure msg
+  OUnit2.assert_failure ("Unexpected spill: " ^ str)
 ;;
 
 let _err_unexpected_coloring (coloring : (Temp.t, int) Map.t) : 'a =
   let str = Map.to_string Temp.to_string Int.to_string coloring in
-  let msg = String.append "Unexpected coloring: " str in
-  OUnit2.assert_failure msg
+  OUnit2.assert_failure ("Unexpected coloring: " ^ str)
 ;;
 
 let _int_set (items : int list) : int Set.t =

--- a/test/soc/backend/analysis/reg_alloc_test.ml
+++ b/test/soc/backend/analysis/reg_alloc_test.ml
@@ -40,9 +40,7 @@ let _check_spills
     let expect_str =
       String.join_with (List.map Temp.to_string expect_spills) ", " in
     let actual_str = Set.to_string Temp.to_string spills in
-    let error_msg =
-      String.concat ["expected: ["; expect_str; "]; actual: "; actual_str]
-    in
+    let error_msg = "expected: [" ^ expect_str ^ "] ^ actual: " ^ actual_str in
     OUnit2.assert_bool error_msg (same_length && is_subset);
   | Ok coloring -> _err_unexpected_coloring coloring
 ;;
@@ -65,15 +63,12 @@ let _check_coloring
     let pair_strs =
       List.map
         (fun (temp, color) ->
-           String.concat
-             ["("; Temp.to_string temp; ", "; Int.to_string color; ")"])
+           "(" ^ (Temp.to_string temp) ^ ", " ^ (Int.to_string color) ^ ")")
         expected_coloring
     in
     let expect_str = String.join_with pair_strs ", " in
     let actual_str = Map.to_string Temp.to_string Int.to_string coloring in
-    let error_msg =
-      String.concat ["expected: ["; expect_str; "]; actual: "; actual_str]
-    in
+    let error_msg = "expected: [" ^ expect_str ^ "] ^ actual: " ^ actual_str in
     OUnit2.assert_bool error_msg (same_length && is_subset);
 ;;
 

--- a/test/soc/backend/cir_test.ml
+++ b/test/soc/backend/cir_test.ml
@@ -2,18 +2,18 @@ open Pervasives
 
 (* [filename] can assume CWD is where this file is *)
 let _get_full_path (filename : string) : string =
-  String.append "../../../../test/soc/backend/cir-resources/" filename
+  "../../../../test/soc/backend/cir-resources/" ^ filename
 ;;
 
 let _check_cir_pp (filepath_no_suffix : string) : unit =
-  let filepath = String.append filepath_no_suffix ".soml" in
+  let filepath = filepath_no_suffix ^ ".soml" in
   let result =
     match Driver.cir_file filepath with
     | Error msg -> msg
     | Ok cir -> Pretty.pp_cir cir
   in
-  let expect_path = String.append filepath_no_suffix ".expect" in
-  let actual_path = String.append filepath_no_suffix ".actual" in
+  let expect_path = filepath_no_suffix ^ ".expect" in
+  let actual_path = filepath_no_suffix ^ ".actual" in
   Test_aux.check_and_output_str result expect_path actual_path;
 ;;
 

--- a/test/soc/common/namer_test.ml
+++ b/test/soc/common/namer_test.ml
@@ -3,20 +3,20 @@ open Pervasives
 
 (* [filename] can assume CWD is where this file is *)
 let _get_full_path (filename : string) : string =
-  String.append "../../../../test/soc/common/namer-resources/" filename
+  "../../../../test/soc/common/namer-resources/" ^ filename
 ;;
 
 let _check_ast_with_renamer
     (filepath_no_suffix : string) (renamer : Ast.structure -> Ast.structure)
   : unit =
-  let filepath = String.append filepath_no_suffix ".soml" in
+  let filepath = filepath_no_suffix ^ ".soml" in
   let result =
     match Driver.parse_file filepath with
     | Error msg -> msg
     | Ok ast -> Pretty.pp_ast_structure (renamer ast)
   in
-  let expect_path = String.append filepath_no_suffix ".expect" in
-  let actual_path = String.append filepath_no_suffix ".actual" in
+  let expect_path = filepath_no_suffix ^ ".expect" in
+  let actual_path = filepath_no_suffix ^ ".actual" in
   Test_aux.check_and_output_str result expect_path actual_path;
 ;;
 

--- a/test/soc/dune
+++ b/test/soc/dune
@@ -2,7 +2,7 @@
   (names
    ; stdlib
    list_test option_test set_test map_test int_test char_test string_test
-   result_test filename_test
+   result_test filename_test pervasives_test
 
    ; frontend
    location_test span_test lexer_test parser_test ast_interp_test typer_test

--- a/test/soc/frontend/interp/ast_interp_test.ml
+++ b/test/soc/frontend/interp/ast_interp_test.ml
@@ -2,7 +2,7 @@ open Pervasives
 
 (* [filename] can assume CWD is where this file is *)
 let _get_full_path (filename : string) : string =
-  String.append "../../../../test/soc/frontend/interp/ast-interp-resources/" filename
+  "../../../../test/soc/frontend/interp/ast-interp-resources/" ^ filename
 ;;
 
 (* print output to stdout *)
@@ -30,9 +30,9 @@ let _run_with_stdout_redirected_to_file
  * redirect output to [filepath_no_suffix.actual],
  * check output against [filepath_no_suffix.expect] *)
 let _check_ast_interp (filepath_no_suffix : string) : unit =
-  let filepath = String.append filepath_no_suffix ".soml" in
-  let expect_path = String.append filepath_no_suffix ".expect" in
-  let actual_path = String.append filepath_no_suffix ".actual" in
+  let filepath = filepath_no_suffix ^ ".soml" in
+  let expect_path = filepath_no_suffix ^ ".expect" in
+  let actual_path = filepath_no_suffix ^ ".actual" in
 
   _run_with_stdout_redirected_to_file
     (fun () -> _interp_file filepath) actual_path;

--- a/test/soc/frontend/parsing/lexer_test.ml
+++ b/test/soc/frontend/parsing/lexer_test.ml
@@ -2,18 +2,18 @@ open Pervasives
 
 (** [filename] can assume CWD is where this file is *)
 let _get_full_path (filename : string) : string =
-  String.append "../../../../test/soc/frontend/parsing/lexer-resources/" filename
+  "../../../../test/soc/frontend/parsing/lexer-resources/" ^ filename
 ;;
 
 let _check_lexer_pp_ast (filepath_no_suffix : string) : unit =
-  let filepath = String.append filepath_no_suffix ".soml" in
+  let filepath = filepath_no_suffix ^ ".soml" in
   let result =
     match Driver.lex_file filepath with
     | Error msg -> msg
     | Ok ast -> String.join_with (List.map Pretty.pp_token ast) "\n"
   in
-  let expect_path = String.append filepath_no_suffix ".expect" in
-  let actual_path = String.append filepath_no_suffix ".actual" in
+  let expect_path = filepath_no_suffix ^ ".expect" in
+  let actual_path = filepath_no_suffix ^ ".actual" in
   Test_aux.check_and_output_str result expect_path actual_path;
 ;;
 

--- a/test/soc/frontend/parsing/parser_test.ml
+++ b/test/soc/frontend/parsing/parser_test.ml
@@ -2,18 +2,18 @@ open Pervasives
 
 (** [filename] can assume CWD is where this file is *)
 let _get_full_path (filename : string) : string =
-  String.append "../../../../test/soc/frontend/parsing/parser-resources/" filename
+  "../../../../test/soc/frontend/parsing/parser-resources/" ^ filename
 ;;
 
 let _check_parser_pp_ast (filepath_no_suffix : string) : unit =
-  let filepath = String.append filepath_no_suffix ".soml" in
+  let filepath = filepath_no_suffix ^ ".soml" in
   let result =
     match Driver.parse_file filepath with
     | Error msg -> msg
     | Ok ast -> Pretty.pp_ast_structure ast
   in
-  let expect_path = String.append filepath_no_suffix ".expect" in
-  let actual_path = String.append filepath_no_suffix ".actual" in
+  let expect_path = filepath_no_suffix ^ ".expect" in
+  let actual_path = filepath_no_suffix ^ ".actual" in
   Test_aux.check_and_output_str result expect_path actual_path;
 ;;
 

--- a/test/soc/frontend/typing/typer_test.ml
+++ b/test/soc/frontend/typing/typer_test.ml
@@ -2,18 +2,18 @@ open Pervasives
 
 (** [filename] can assume CWD is where this file is *)
 let _get_full_path (filename : string) : string =
-  String.append "../../../../test/soc/frontend/typing/resources/" filename
+  "../../../../test/soc/frontend/typing/resources/" ^ filename
 ;;
 
 let _check_typer_struct (filepath_no_suffix : string) : unit =
-  let filepath = String.append filepath_no_suffix ".soml" in
+  let filepath = filepath_no_suffix ^ ".soml" in
   let result =
     match Driver.type_file filepath with
     | Error msg -> msg
     | Ok ast -> Pretty.pp_ast_structure_with_typ_annot ast
   in
-  let expect_path = String.append filepath_no_suffix ".expect" in
-  let actual_path = String.append filepath_no_suffix ".actual" in
+  let expect_path = filepath_no_suffix ^ ".expect" in
+  let actual_path = filepath_no_suffix ^ ".actual" in
   Test_aux.check_and_output_str result expect_path actual_path;
 ;;
 

--- a/test/soc/stdlib/int_test.ml
+++ b/test/soc/stdlib/int_test.ml
@@ -1,4 +1,3 @@
-open Pervasives
 
 let tests = OUnit2.(>:::) "int_test" [
     OUnit2.(>::) "test_max" (fun _ ->
@@ -39,15 +38,6 @@ let tests = OUnit2.(>:::) "int_test" [
         OUnit2.assert_equal "42" (Int.to_string 42);
         OUnit2.assert_equal "0" (Int.to_string 0);
         OUnit2.assert_equal "-13" (Int.to_string ~-13);
-      );
-
-    OUnit2.(>::) "test_of_string_opt" (fun _ ->
-        OUnit2.assert_equal None (Int.of_string_opt "");
-        OUnit2.assert_equal None (Int.of_string_opt "12o3");
-        OUnit2.assert_equal None (Int.of_string_opt "o000");
-        OUnit2.assert_equal (Some 0) (Int.of_string_opt "000");
-        OUnit2.assert_equal (Some ~-42) (Int.of_string_opt "-42");
-        OUnit2.assert_equal (Some 7) (Int.of_string_opt "7");
       );
   ]
 

--- a/test/soc/stdlib/list_test.ml
+++ b/test/soc/stdlib/list_test.ml
@@ -33,7 +33,7 @@ let tests = OUnit2.(>:::) "list_tests" [
         OUnit2.assert_equal [] (List.map double []);
         OUnit2.assert_equal [2; 6; 10] (List.map double [1; 3; 5]);
         let x = ref "" in
-        let append n = x := (String.append !x (Int.to_string n)) in
+        let append n = x := (!x ^ (Int.to_string n)) in
         let _ = List.map append [1; 3; 5] in
         OUnit2.assert_equal "135" !x;
       );
@@ -42,14 +42,14 @@ let tests = OUnit2.(>:::) "list_tests" [
         OUnit2.assert_equal [] (List.mapi (+) []);
         OUnit2.assert_equal [1; 4; 7] (List.mapi (+) [1; 3; 5]);
         let x = ref "" in
-        let append _ n = x := (String.append !x (Int.to_string n)) in
+        let append _ n = x := (!x ^ (Int.to_string n)) in
         let _ = List.mapi append [1; 3; 5] in
         OUnit2.assert_equal "135" !x;
       );
 
     OUnit2.(>::) "test_iter" (fun _ ->
         let x = ref "" in
-        let append n = x := (String.append !x (Int.to_string n)) in
+        let append n = x := (!x ^ (Int.to_string n)) in
         let _ = List.map append [1; 3; 5] in
         OUnit2.assert_equal "135" !x;
       );

--- a/test/soc/stdlib/list_test.ml
+++ b/test/soc/stdlib/list_test.ml
@@ -18,14 +18,6 @@ let tests = OUnit2.(>:::) "list_tests" [
         OUnit2.assert_equal [[2; 3]; []; [1]] (List.rev [[1]; []; [2; 3]]);
       );
 
-
-    OUnit2.(>::) "test_append" (fun _ ->
-        OUnit2.assert_equal [] (List.append [] []);
-        OUnit2.assert_equal [1] (List.append [] [1]);
-        OUnit2.assert_equal [1] (List.append [1] []);
-        OUnit2.assert_equal [1; 2; 3; 4] (List.append [1; 2] [3; 4]);
-      );
-    
     OUnit2.(>::) "test_concat" (fun _ ->
         OUnit2.assert_equal [] (List.concat []);
         OUnit2.assert_equal [1; 3; 5] (List.concat [[1]; []; [3; 5]])

--- a/test/soc/stdlib/pervasives_test.ml
+++ b/test/soc/stdlib/pervasives_test.ml
@@ -7,6 +7,15 @@ let tests = OUnit2.(>:::) "pervasives_tests" [
         OUnit2.assert_equal false (not true);
       );
 
+    OUnit2.(>::) "test_int_of_string_opt" (fun _ ->
+        OUnit2.assert_equal None (int_of_string_opt "");
+        OUnit2.assert_equal None (int_of_string_opt "12o3");
+        OUnit2.assert_equal None (int_of_string_opt "o000");
+        OUnit2.assert_equal (Some 0) (int_of_string_opt "000");
+        OUnit2.assert_equal (Some ~-42) (int_of_string_opt "-42");
+        OUnit2.assert_equal (Some 7) (int_of_string_opt "7");
+      );
+
     (* sanity check on purity *)
     OUnit2.(>::) "test_pipeline" (fun _ ->
         let add1 x = x + 1 in

--- a/test/soc/stdlib/pervasives_test.ml
+++ b/test/soc/stdlib/pervasives_test.ml
@@ -36,6 +36,13 @@ let tests = OUnit2.(>:::) "pervasives_tests" [
         OUnit2.assert_equal [1] ([1] @ []);
         OUnit2.assert_equal [1; 2; 3; 4] ([1; 2] @ [3; 4]);
       );
+
+    OUnit2.(>::) "test_string_append" (fun _ ->
+        OUnit2.assert_equal "" ("" ^ "");
+        OUnit2.assert_equal "123" ("" ^ "123");
+        OUnit2.assert_equal "abc" ("abc" ^ "");
+        OUnit2.assert_equal "fo-obar" ("fo" ^ "-obar");
+      );
   ]
 
 let _ =

--- a/test/soc/stdlib/pervasives_test.ml
+++ b/test/soc/stdlib/pervasives_test.ml
@@ -1,0 +1,33 @@
+open Pervasives
+
+let tests = OUnit2.(>:::) "pervasives_tests" [
+
+    OUnit2.(>::) "test_not" (fun _ ->
+        OUnit2.assert_equal true (not false);
+        OUnit2.assert_equal false (not true);
+      );
+
+    (* sanity check on purity *)
+    OUnit2.(>::) "test_pipeline" (fun _ ->
+        let add1 x = x + 1 in
+        OUnit2.assert_equal 1 (0 |> add1);
+        OUnit2.assert_equal 4 (1 |> add1 |> add1 |> add1);
+      );
+
+    (* sanity check on purity *)
+    OUnit2.(>::) "test_apply" (fun _ ->
+        let add1 x = x + 1 in
+        OUnit2.assert_equal 11 (add1 @@ 2 * 5);
+        OUnit2.assert_equal 13 (add1 @@ 3 * 4);
+      );
+
+    OUnit2.(>::) "test_list_append" (fun _ ->
+        OUnit2.assert_equal [] ([] @ []);
+        OUnit2.assert_equal [1] ([] @ [1]);
+        OUnit2.assert_equal [1] ([1] @ []);
+        OUnit2.assert_equal [1; 2; 3; 4] ([1; 2] @ [3; 4]);
+      );
+  ]
+
+let _ =
+  OUnit2.run_test_tt_main tests

--- a/test/soc/stdlib/string_test.ml
+++ b/test/soc/stdlib/string_test.ml
@@ -19,13 +19,6 @@ let tests = OUnit2.(>:::) "string_test" [
         OUnit2.assert_equal "$" (String.sub "ax$" 2 1);
       );
 
-    OUnit2.(>::) "test_append" (fun _ ->
-        OUnit2.assert_equal "" (String.append "" "");
-        OUnit2.assert_equal "123" (String.append "" "123");
-        OUnit2.assert_equal "abc" (String.append "abc" "");
-        OUnit2.assert_equal "fo-obar" (String.append "fo" "-obar");
-      );
-
     OUnit2.(>::) "test_compare" (fun _ ->
         OUnit2.assert_equal true ((String.compare "ab0" "ab0") = 0);
         OUnit2.assert_equal true ((String.compare "ab" "ab0") < 0);

--- a/test/soc/stdlib/string_test.ml
+++ b/test/soc/stdlib/string_test.ml
@@ -32,11 +32,6 @@ let tests = OUnit2.(>:::) "string_test" [
         OUnit2.assert_equal "ss" (String.join_with ["ss"] "aaa");
         OUnit2.assert_equal "a; bb; a" (String.join_with ["a"; "bb"; "a"] "; ");
       );
-
-    OUnit2.(>::) "test_concat" (fun _ ->
-        OUnit2.assert_equal "" (String.concat []);
-        OUnit2.assert_equal "a cc" (String.concat ["a"; " "; "cc"]);
-      );
   ]
 
 let _ =


### PR DESCRIPTION
Add some infix operators to custom `Pervasives` module to
- clean up some code
- make the codebase more self-contained