### PR TITLE
Refactor externals and pervasives

### DIFF
--- a/lib/stdlib/externals.ml
+++ b/lib/stdlib/externals.ml
@@ -12,8 +12,11 @@
       another one that uses the `external` keyword, and link against my runtime
       code. Single point of control:).
     
-    NOTE Don't use it outside the stdlib directory, so that one day we can
-    easily swap it out.
+    NOTE 
+    - Don't use this module outside the stdlib directory, so that one day we can
+      easily swap it out.
+    - This module should depend on no other modules in the compiler codebase.
+      Think of it as sitting on the outermost edge of the compiler.
     *)
 
 type 'a list = 
@@ -30,16 +33,16 @@ type ('a, 'e) result =
 
 
 let read_entire_file (filename : string) : string =
-  let ch = open_in filename in
-  let s = really_input_string ch (in_channel_length ch) in
-  close_in ch;
+  let ch = Stdlib.open_in filename in
+  let s = Stdlib.really_input_string ch (Stdlib.in_channel_length ch) in
+  Stdlib.close_in ch;
   s
 ;;
 
 let write_entire_file (filename : string) (content : string) : unit =
-  let oc = open_out filename in
-  output_string oc content;
-  close_out oc;
+  let oc = Stdlib.open_out filename in
+  Stdlib.output_string oc content;
+  Stdlib.close_out oc;
 ;;
 
 let print s =
@@ -71,7 +74,7 @@ let string_get = Stdlib.String.get
 let string_sub = Stdlib.String.sub
 ;;
 
-let string_append = (^)
+let string_append = Stdlib.(^)
 ;;
 
 let raise = Stdlib.raise

--- a/lib/stdlib/externals.ml
+++ b/lib/stdlib/externals.ml
@@ -74,5 +74,5 @@ let string_sub = Stdlib.String.sub
 let string_append = (^)
 ;;
 
-let failwith = failwith
+let raise = Stdlib.raise
 ;;

--- a/lib/stdlib/externals.ml
+++ b/lib/stdlib/externals.ml
@@ -16,6 +16,19 @@
     easily swap it out.
     *)
 
+type 'a list = 
+  | []
+  | (::) of 'a * 'a list
+
+type 'a option =
+  | None
+  | Some of 'a
+
+type ('a, 'e) result =
+  | Ok of 'a
+  | Error of 'e
+
+
 let read_entire_file (filename : string) : string =
   let ch = open_in filename in
   let s = really_input_string ch (in_channel_length ch) in
@@ -43,7 +56,10 @@ let char_to_string = Stdlib.Char.escaped
 let int_to_string = Stdlib.string_of_int
 ;;
 
-let int_of_string = Stdlib.int_of_string
+let int_of_string_opt s = 
+  match Stdlib.int_of_string_opt s with
+  | Some n -> Some n
+  | None -> None
 ;;
 
 let string_length = Stdlib.String.length

--- a/lib/stdlib/pervasives.ml
+++ b/lib/stdlib/pervasives.ml
@@ -1,13 +1,13 @@
 
-type 'a list = 
+type 'a list         = 'a Externals.list =
   | []
   | (::) of 'a * 'a list
 
-type 'a option =
+type 'a option       = 'a Externals.option =
   | None
   | Some of 'a
 
-type ('a, 'e) result =
+type ('a, 'e) result = ('a, 'e) Externals.result =
   | Ok of 'a
   | Error of 'e
 
@@ -15,9 +15,8 @@ let not b =
   if b then false else true
 ;;
 
-let int_of_string_opt s =
-  try Some (Externals.int_of_string s)
-  with Failure _ -> None
+let int_of_string_opt =
+  Externals.int_of_string_opt
 ;;
 
 let (|>) a f =

--- a/lib/stdlib/pervasives.ml
+++ b/lib/stdlib/pervasives.ml
@@ -36,3 +36,11 @@ let rec (@) xs ys =
 let (^) =
   Externals.string_append
 ;;
+
+let raise =
+  Externals.raise
+;;
+
+let failwith msg =
+  raise (Failure msg)
+;;

--- a/lib/stdlib/pervasives.mli
+++ b/lib/stdlib/pervasives.mli
@@ -29,7 +29,7 @@ val (@@) : ('a -> 'b) -> 'a -> 'b
 
 (** [xs @ ys] is a list with elements of [xs] added to the front of [ys] in
     order *)
-val (@)  : 'a list -> 'a list -> 'a list
+val (@) : 'a list -> 'a list -> 'a list
 
 (** [s1 ^ s2] is a string with [s1] and [s2] appended together *)
 val (^) : string -> string -> string

--- a/lib/stdlib/pervasives.mli
+++ b/lib/stdlib/pervasives.mli
@@ -3,21 +3,15 @@
    Centralizing the "auto-loaded" functions here makes self-compilation easier.
    For now we'll just manually open it in each file, if needed. TODO *)
 
-
-(** NOTE
-    These types are built-in to the OCaml compiler.
-    I decided to declare them explicitly for now; to make them built-in, simply
-    add them into the initial environment and remove these definitions *)
-
-type 'a list = 
+type 'a list         = 'a Externals.list =
   | []
   | (::) of 'a * 'a list
 
-type 'a option =
+type 'a option       = 'a Externals.option =
   | None
   | Some of 'a
 
-type ('a, 'e) result =
+type ('a, 'e) result = ('a, 'e) Externals.result =
   | Ok of 'a
   | Error of 'e
 

--- a/lib/stdlib/pervasives.mli
+++ b/lib/stdlib/pervasives.mli
@@ -1,8 +1,12 @@
 
 (* The OCaml compiler loads the pervasives module by default.
    Centralizing the "auto-loaded" functions here makes self-compilation easier.
-   For now we'll just manually open it in each file, if needed. TODO *)
+   For now we'll just manually open it in each file, if needed. *)
 
+(* NOTE these type definitions are technically redundant, but they help enforce
+ * the separation between our custom stdlib and OCaml's built-in stdlib. 
+ * TODO they will be completely removed once we add them as pre-defined types in
+ * the compiler. *)
 type 'a list         = 'a Externals.list =
   | []
   | (::) of 'a * 'a list

--- a/lib/stdlib/pervasives.mli
+++ b/lib/stdlib/pervasives.mli
@@ -33,3 +33,10 @@ val (@)  : 'a list -> 'a list -> 'a list
 
 (** [s1 ^ s2] is a string with [s1] and [s2] appended together *)
 val (^) : string -> string -> string
+
+(** [raise exn] will transfer control flow to the dynamically enclosing
+    try-with block that expects [exn], or print out the error at top-level. *)
+val raise : exn -> 'a
+
+(** [failwith msg] = [raise (Failure msg)] *)
+val failwith : string -> 'a


### PR DESCRIPTION
`Externals` and `Pervasives` modules play special roles for self-compiling the compiler
- `Pervasives` contains common types and values used throughout the compiler codebase
- `Externals` contains definitions of values or types that must eventually be defined in runtime or compiler environment