### PR TITLE
Singleton string set and map

### DIFF
--- a/lib/backend/analysis/vasm.ml
+++ b/lib/backend/analysis/vasm.ml
@@ -150,7 +150,7 @@ let _ctx_init : context =
   let ctx = { next_block_id        = 0
             ; curr_block_id        = -1 (* temporary garbage *)
             ; rev_curr_block_vasms = []
-            ; label_to_block_id    = Map.empty String.compare
+            ; label_to_block_id    = String.empty_map ()
             ; id_to_block_info     = Map.empty Int.compare
             ; block_id_graph       = Graph.empty_graph () 
             ; rev_finished_nodes   = [] }

--- a/lib/backend/cir.ml
+++ b/lib/backend/cir.ml
@@ -44,7 +44,7 @@ type context =
   }
 
 let _init_ctx namer =
-  { closures = Map.empty String.compare; namer }
+  { closures = String.empty_map (); namer }
 ;;
 
 let _gen_new_var_name (ctx : context) (prefix : string) : (context * string) =
@@ -82,7 +82,7 @@ let rec _free_vars_in_expr (expr : Ast.expression) : string Set.t =
     | Exp_ident name  -> Set.add name free_vars
     | Exp_fun (otvs, body) ->
       let names = List.map (fun (otv : Ast.opt_typed_var) -> otv.var) otvs in
-      let body_fvs = go (Set.empty String.compare) body in
+      let body_fvs = go String.empty_set body in
       let body_fvs = List.fold_right Set.remove names body_fvs in
       Set.union free_vars body_fvs
 
@@ -93,7 +93,7 @@ let rec _free_vars_in_expr (expr : Ast.expression) : string Set.t =
 
     | Exp_let (rec_flag, bds, body) ->
       let names, bds_fvs = _names_and_fvs_in_let_bds rec_flag bds in
-      let body_fvs = go (Set.empty String.compare) body in
+      let body_fvs = go String.empty_set body in
       let body_fvs = List.fold_right Set.remove names body_fvs in
       Set.union bds_fvs (Set.union free_vars body_fvs)
 
@@ -101,7 +101,7 @@ let rec _free_vars_in_expr (expr : Ast.expression) : string Set.t =
       let free_vars = go free_vars func in
       List.fold_left go free_vars args
   in
-  go (Set.empty String.compare) expr
+  go String.empty_set expr
 
 and _names_and_fvs_in_let_bds rec_flag bds =
   let names, rhs_fvs = 
@@ -111,7 +111,7 @@ and _names_and_fvs_in_let_bds rec_flag bds =
          let one_rhs_fvs = _free_vars_in_expr bd.binding_rhs in
          let rhs_fvs = Set.union one_rhs_fvs rhs_fvs in
          (names, rhs_fvs))
-        ([], Set.empty String.compare) bds
+        ([], String.empty_set) bds
   in
   match rec_flag with (* think about scoping rules for let rec *)
   | Nonrecursive -> (names, rhs_fvs)

--- a/lib/backend/common/label.ml
+++ b/lib/backend/common/label.ml
@@ -45,7 +45,7 @@ type manager =
 
 let init_manager =
   { next_stamp = 0
-  ; name_cache = Map.empty String.compare
+  ; name_cache = String.empty_map ()
   }
 ;;
 

--- a/lib/backend/common/temp.ml
+++ b/lib/backend/common/temp.ml
@@ -16,7 +16,7 @@ type manager =
 
 let init_manager =
   { next_t     = _init_t
-  ; name_cache = Map.empty String.compare
+  ; name_cache = String.empty_map ()
   }
 ;;
 

--- a/lib/common/namer.ml
+++ b/lib/common/namer.ml
@@ -32,7 +32,7 @@ type rename_context =
 
 let _init_ctx t =
   { namer            = t
-  ; curr_scope       = Map.empty String.compare
+  ; curr_scope       = String.empty_map ()
   ; prev_scopes      = []
   }
 

--- a/lib/common/primops.ml
+++ b/lib/common/primops.ml
@@ -55,7 +55,7 @@ let all_op_infos =
 let _info_map : (string, op_info) Map.t =
   List.fold_left
     (fun map (info : op_info) -> Map.add info.opstr info map)
-    (Map.empty String.compare) all_op_infos
+    (String.empty_map ()) all_op_infos
 ;;
 
 let get_type s =

--- a/lib/frontend/interp/ast_interp.ml
+++ b/lib/frontend/interp/ast_interp.ml
@@ -347,7 +347,7 @@ let _interp_struct_item (ctx : context) (item : Ast.struct_item) : context =
 ;;
 
 let _interp_struct_impl items =
-  let init_ctx = Map.empty String.compare in
+  let init_ctx = String.empty_map () in
   let init_ctx = Map.add "println" (Native Builtin_println) init_ctx in
   let init_ctx = Map.add "=" (Native Builtin_equal) init_ctx in
   let init_ctx =

--- a/lib/frontend/parsing/lexer.ml
+++ b/lib/frontend/parsing/lexer.ml
@@ -51,7 +51,7 @@ let _keyword_map : (string, Token.desc) Map.t =
       ("true",  Token.True);
       ("false",  Token.False);
     ]
-    (Map.empty String.compare)
+    (String.empty_map ())
 ;;
 
 (* Used for lexing operators *)

--- a/lib/frontend/typing/substs.ml
+++ b/lib/frontend/typing/substs.ml
@@ -6,8 +6,8 @@ open Pervasives
  *    being root nodes (could itself be a tyvar, but can't appear in keys). *)
 type t = (string, Ast.typ) Map.t
 
-let empty = Map.empty String.compare
-
+let empty = String.empty_map ()
+;;
 
 let rec apply_to_typ_exclude t (desc : Ast.typ) ignored =
   match desc with

--- a/lib/frontend/typing/typer_ctx.ml
+++ b/lib/frontend/typing/typer_ctx.ml
@@ -67,7 +67,7 @@ let get_errors t =
 
 
 let open_scope t =
-  { t with cur_var_env = Map.empty String.compare
+  { t with cur_var_env   = String.empty_map ()
          ; prev_var_envs = t.cur_var_env::t.prev_var_envs }
 ;;
 
@@ -183,7 +183,7 @@ let _add_fvs_in_var_env (s : string Set.t) (var_env : (string, scheme) Map.t)
 (* A helper for generalize 1 name in var_env *)
 let _generalize_typ (typ : Ast.typ) (fvs_in_var_env : string Set.t)
   : scheme =
-  let fvs = Set.empty String.compare in
+  let fvs = String.empty_set in
   let fvs = _add_fvs_in_typ fvs typ in
   let fvs = Set.diff fvs fvs_in_var_env in
   let free_tyvars = Set.to_list fvs in
@@ -193,12 +193,11 @@ let _generalize_typ (typ : Ast.typ) (fvs_in_var_env : string Set.t)
 
 let generalize t names =
   (* ignore the names themselves in context, since their tyvars are not free *)
-  let names_to_ignore =
-    List.fold_right Set.add names (Set.empty String.compare) in
+  let names_to_ignore = List.fold_right Set.add names String.empty_set in
   let fvs_in_var_env =
     List.fold_left
       (fun s var_env -> _add_fvs_in_var_env s var_env names_to_ignore)
-      (Set.empty String.compare) (t.cur_var_env::t.prev_var_envs)
+      String.empty_set (t.cur_var_env::t.prev_var_envs)
   in
   List.fold_left
     (fun t name ->
@@ -224,7 +223,7 @@ let _add_primops_into_var_env (var_env : (string, scheme) Map.t)
   : (string, scheme) Map.t =
   List.fold_left
     (fun env (info : Primops.op_info) ->
-       let schm = _generalize_typ info.typ (Set.empty String.compare) in
+       let schm = _generalize_typ info.typ String.empty_set in
        Map.add info.opstr schm env)
     var_env Primops.all_op_infos
 ;;
@@ -240,13 +239,13 @@ let _add_natives_into_var_env (var_env : (string, scheme) Map.t)
   in
   List.fold_left
     (fun var_env (name, typ) ->
-       Map.add name (_generalize_typ typ (Set.empty String.compare)) var_env)
+       Map.add name (_generalize_typ typ String.empty_set) var_env)
     var_env name_typ_pairs
 ;;
 
 (* Initialize with some built-in stuff, an ad hoc solution *)
 let create namer =
-  let cur_var_env = Map.empty String.compare in
+  let cur_var_env = String.empty_map () in
   (* It's okay to have custom tyvars in primops/natives, because we won't
    * generate new tyvars inside them anymore, and tyvar scope is limited to
    * each top-level *)

--- a/lib/stdlib/list.ml
+++ b/lib/stdlib/list.ml
@@ -151,6 +151,6 @@ let init size f =
 
 let to_string xs f =
   let elem_strs = map f xs in
-  let elems_str = String.join_with elem_strs "; " in
+  let elems_str = Stdlib_util.str_join_with elem_strs "; " in
   "[" ^ elems_str ^ "]"
 ;;

--- a/lib/stdlib/map.ml
+++ b/lib/stdlib/map.ml
@@ -80,9 +80,9 @@ let to_string f g t =
   let pair_to_str (k, v) =
     "(" ^ (f k) ^ ", " ^ (g v) ^ ")"
   in
-  let pairs = List.map pair_to_str (_unique_pairs t) in
-  let inner = String.join_with pairs "; " in
-  "{" ^ inner ^ "}"
+  let pair_strs = List.map pair_to_str (_unique_pairs t) in
+  let pairs_str = Stdlib_util.str_join_with pair_strs "; " in
+  "{" ^ pairs_str ^ "}"
 ;;
 
 let get_key_set t =

--- a/lib/stdlib/set.ml
+++ b/lib/stdlib/set.ml
@@ -95,9 +95,9 @@ let to_list t =
 ;;
 
 let to_string f t =
-  let es = List.map f (_unique_elems t) in
-  let inner = String.join_with es "; " in
-  "{" ^ inner ^ "}"
+  let e_strs = List.map f (_unique_elems t) in
+  let es_str = Stdlib_util.str_join_with e_strs "; " in
+  "{" ^ es_str ^ "}"
 ;;
 
 let get_compare_func t =

--- a/lib/stdlib/stdlib_util.ml
+++ b/lib/stdlib/stdlib_util.ml
@@ -1,0 +1,14 @@
+open Pervasives
+
+let str_join_with init_ss sep =
+  match init_ss with
+  | [] -> ""
+  | fst_s::rst_ss ->
+    let rec go acc ss =
+      match ss with
+      | [] -> acc
+      | s::ss ->
+        let acc = acc ^ sep ^ s in
+        go acc ss
+    in go fst_s rst_ss
+;;

--- a/lib/stdlib/stdlib_util.mli
+++ b/lib/stdlib/stdlib_util.mli
@@ -1,0 +1,7 @@
+open Pervasives
+
+(* This module "lifts out" some functions to eliminate cyclic dependencies *)
+
+
+(** [str_join_with [s1; ...; sn] sep] is [s1 ^ sep ^ ... ^ sep ^ sn] *)
+val str_join_with : string list -> string -> string

--- a/lib/stdlib/string.ml
+++ b/lib/stdlib/string.ml
@@ -25,3 +25,11 @@ let compare s1 s2 =
 let join_with =
   Stdlib_util.str_join_with
 ;;
+
+let empty_set =
+  Set.empty compare
+;;
+
+let empty_map () =
+  Map.empty compare
+;;

--- a/lib/stdlib/string.ml
+++ b/lib/stdlib/string.ml
@@ -1,4 +1,3 @@
-open Pervasives
 
 let length = Externals.string_length
 ;;
@@ -7,9 +6,6 @@ let get = Externals.string_get
 ;;
 
 let sub = Externals.string_sub
-;;
-
-let append = Externals.string_append
 ;;
 
 let compare s1 s2 =
@@ -26,15 +22,6 @@ let compare s1 s2 =
   go 0
 ;;
 
-let join_with init_ss sep =
-  match init_ss with
-  | [] -> ""
-  | fst_s::rst_ss ->
-    let rec go acc ss =
-      match ss with
-      | [] -> acc
-      | s::ss ->
-        let acc = append (append acc sep) s in
-        go acc ss
-    in go fst_s rst_ss
+let join_with =
+  Stdlib_util.str_join_with
 ;;

--- a/lib/stdlib/string.mli
+++ b/lib/stdlib/string.mli
@@ -16,3 +16,10 @@ val compare : string -> string -> int
 (** [join_with [s1; ...; sn] sep] is [s1 ^ sep ^ ... ^ sep ^ sn] where [^]
     stands for the append operation *)
 val join_with : string list -> string -> string
+
+(** An empty set of [t], with _some_ ordering. *)
+val empty_set : string Set.t
+
+(** [empty_map ()] is an empty map of [t], using [compare] for ordering.
+    It's made a function to support parameterized key type. *)
+val empty_map : unit -> (string, 'v) Map.t

--- a/test/soc/stdlib/stdlib_util_test.ml
+++ b/test/soc/stdlib/stdlib_util_test.ml
@@ -1,0 +1,13 @@
+
+let tests = OUnit2.(>:::) "stdlib_util_test" [
+
+    OUnit2.(>::) "test_str_join_with" (fun _ ->
+        OUnit2.assert_equal "" (Stdlib_util.str_join_with [] "");
+        OUnit2.assert_equal "" (Stdlib_util.str_join_with [] "aaa");
+        OUnit2.assert_equal "ss" (Stdlib_util.str_join_with ["ss"] "aaa");
+        OUnit2.assert_equal "a; bb; a" (Stdlib_util.str_join_with ["a"; "bb"; "a"] "; ");
+      );
+  ]
+
+let _ =
+  OUnit2.run_test_tt_main tests


### PR DESCRIPTION
Similar to #61.

`String.compare` is kept because
- We should test it
- `Label` needs it